### PR TITLE
Refactor gRPC and SignalR tag subscriptions

### DIFF
--- a/src/DataCore.Adapter.AspNetCore.Common/RealTimeData/SnapshotSubscriptionWrapper.cs
+++ b/src/DataCore.Adapter.AspNetCore.Common/RealTimeData/SnapshotSubscriptionWrapper.cs
@@ -113,10 +113,6 @@ namespace DataCore.Adapter.AspNetCore.RealTimeData {
                 return null;
             }
 
-            if (!await _subscription.AddTagToSubscription(tagId).ConfigureAwait(false)) {
-                return null;
-            }
-
             var subscription = new SnapshotTagSubscription(tagId, RemoveSubscription);
 
             _subscribersLock.EnterWriteLock();
@@ -129,6 +125,11 @@ namespace DataCore.Adapter.AspNetCore.RealTimeData {
             }
             finally {
                 _subscribersLock.ExitWriteLock();
+            }
+
+            if (!await _subscription.AddTagToSubscription(tagId).ConfigureAwait(false)) {
+                subscription.Dispose();
+                return null;
             }
 
             return subscription;

--- a/src/DataCore.Adapter.AspNetCore.Common/RealTimeData/SnapshotSubscriptionWrapper.cs
+++ b/src/DataCore.Adapter.AspNetCore.Common/RealTimeData/SnapshotSubscriptionWrapper.cs
@@ -1,0 +1,189 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Threading;
+using System.Threading.Tasks;
+using DataCore.Adapter.RealTimeData;
+using IntelligentPlant.BackgroundTasks;
+
+namespace DataCore.Adapter.AspNetCore.RealTimeData {
+    /// <summary>
+    /// Wraps an <see cref="ISnapshotTagValueSubscription"/> to allow individual, disposable 
+    /// tag subscriptions to be created.
+    /// </summary>
+    public sealed class SnapshotSubscriptionWrapper : IDisposable {
+
+        /// <summary>
+        /// Flags if the object has been disposed.
+        /// </summary>
+        private int _isDisposed;
+
+        /// <summary>
+        /// Fires when the object is disposed.
+        /// </summary>
+        private readonly CancellationTokenSource _disposedTokenSource = new CancellationTokenSource();
+
+        /// <summary>
+        /// The wrapped subscription.
+        /// </summary>
+        private readonly ISnapshotTagValueSubscription _subscription;
+
+        /// <summary>
+        /// Lock for accessing <see cref="_subscribers"/>.
+        /// </summary>
+        private readonly ReaderWriterLockSlim _subscribersLock = new ReaderWriterLockSlim(LockRecursionPolicy.SupportsRecursion);
+
+        /// <summary>
+        /// Active tag subscriptions, indexed by tag ID.
+        /// </summary>
+        private readonly Dictionary<string, List<SnapshotTagSubscription>> _subscribers = new Dictionary<string, List<SnapshotTagSubscription>>(StringComparer.OrdinalIgnoreCase);
+
+
+        /// <summary>
+        /// Creates a new <see cref="SnapshotSubscriptionWrapper"/> object.
+        /// </summary>
+        /// <param name="subscription">
+        ///   The subscription to wrap.
+        /// </param>
+        /// <param name="backgroundTaskService">
+        ///   The <see cref="IBackgroundTaskService"/> to use when running subscriptions in 
+        ///   background work items. Specify <see langword="null"/> to use 
+        ///   <see cref="BackgroundTaskService.Default"/>.
+        /// </param>
+        /// <exception cref="ArgumentNullException">
+        ///   <paramref name="subscription"/> is <see langword="null"/>.
+        /// </exception>
+        public SnapshotSubscriptionWrapper(
+            ISnapshotTagValueSubscription subscription,
+            IBackgroundTaskService backgroundTaskService = null
+        ) {
+            _subscription = subscription ?? throw new ArgumentNullException(nameof(subscription));
+            (backgroundTaskService ?? BackgroundTaskService.Default).QueueBackgroundWorkItem(ct => _subscription.Reader.ForEachAsync(async item => {
+                var subscribers = new List<SnapshotTagSubscription>();
+                _subscribersLock.EnterReadLock();
+                try {
+                    if (_subscribers.TryGetValue(item.TagId, out var idSubscribers)) {
+                        subscribers.AddRange(idSubscribers);
+                    }
+                    if (_subscribers.TryGetValue(item.TagName, out var nameSubscribers)) {
+                        subscribers.AddRange(nameSubscribers);
+                    }
+                }
+                finally {
+                    _subscribersLock.ExitReadLock();
+                }
+
+                foreach (var subscriber in subscribers) {
+                    await subscriber.WriteAsync(item, ct).ConfigureAwait(false);
+                }
+            }, ct), _disposedTokenSource.Token);
+        }
+
+
+        /// <summary>
+        /// Gets the total number of subscriptions.
+        /// </summary>
+        /// <returns>
+        ///   The subscription count.
+        /// </returns>
+        public int GetSubscriptionCount() {
+            _subscribersLock.EnterReadLock();
+            try {
+                return _subscribers.Sum(x => x.Value.Count);
+            }
+            finally {
+                _subscribersLock.ExitReadLock();
+            }
+        }
+
+
+        /// <summary>
+        /// Adds a subscription to the specified tag.
+        /// </summary>
+        /// <param name="tagId">
+        ///   The tag ID or name.
+        /// </param>
+        /// <returns>
+        ///   A <see cref="ValueTask{TResult}"/> that will return a new <see cref="SnapshotTagSubscription"/> 
+        ///   object. The result value will be <see langword="null"/> if the subscription 
+        ///   could not be created.
+        /// </returns>
+        public async ValueTask<SnapshotTagSubscription> AddSubscription(string tagId) {
+            if (string.IsNullOrWhiteSpace(tagId)) {
+                return null;
+            }
+
+            if (!await _subscription.AddTagToSubscription(tagId).ConfigureAwait(false)) {
+                return null;
+            }
+
+            var subscription = new SnapshotTagSubscription(tagId, RemoveSubscription);
+
+            _subscribersLock.EnterWriteLock();
+            try {
+                if (!_subscribers.TryGetValue(tagId, out var subscribers)) {
+                    subscribers = new List<SnapshotTagSubscription>();
+                    _subscribers[tagId] = subscribers;
+                }
+                subscribers.Add(subscription);
+            }
+            finally {
+                _subscribersLock.ExitWriteLock();
+            }
+
+            return subscription;
+        }
+
+
+        /// <summary>
+        /// Removes the specified tag subscription.
+        /// </summary>
+        /// <param name="subscription">
+        ///   The tag subsription.
+        /// </param>
+        private void RemoveSubscription(SnapshotTagSubscription subscription) {
+            _subscribersLock.EnterWriteLock();
+            try {
+                if (!_subscribers.TryGetValue(subscription.TagId, out var subscribers)) {
+                    return;
+                }
+
+                subscribers.Remove(subscription);
+                if (subscribers.Count == 0) {
+                    _subscribers.Remove(subscription.TagId);
+                }
+            }
+            finally {
+                _subscribersLock.ExitWriteLock();
+            }
+        }
+
+
+        /// <inheritdoc/>
+        public void Dispose() {
+            if (Interlocked.CompareExchange(ref _isDisposed, 1, 0) != 0) {
+                return;
+            }
+
+            _disposedTokenSource.Cancel();
+            _disposedTokenSource.Dispose();
+            _subscription.Dispose();
+
+            _subscribersLock.EnterWriteLock();
+            try {
+                foreach (var subscriberList in _subscribers.Values.ToArray()) {
+                    foreach (var item in subscriberList.ToArray()) {
+                        item.Dispose();
+                    }
+                }
+                _subscribers.Clear();
+            }
+            finally {
+                _subscribersLock.ExitWriteLock();
+            }
+
+            _subscribersLock.Dispose();
+        }
+
+    }
+}

--- a/src/DataCore.Adapter.AspNetCore.Common/RealTimeData/SnapshotTagSubscription.cs
+++ b/src/DataCore.Adapter.AspNetCore.Common/RealTimeData/SnapshotTagSubscription.cs
@@ -1,0 +1,87 @@
+﻿using System;
+using System.Threading;
+using System.Threading.Channels;
+using System.Threading.Tasks;
+using DataCore.Adapter.RealTimeData;
+
+namespace DataCore.Adapter.AspNetCore.RealTimeData {
+    /// <summary>
+    /// A subscription to an individual tag created by a <see cref="SnapshotSubscriptionWrapper"/>.
+    /// </summary>
+    public sealed class SnapshotTagSubscription : IDisposable {
+
+        /// <summary>
+        /// Flags if the object has been disposed.
+        /// </summary>
+        private int _isDisposed;
+
+        /// <summary>
+        /// A callback that is invoked when the subscription is disposed.
+        /// </summary>
+        private readonly Action<SnapshotTagSubscription> _onDisposed;
+
+        /// <summary>
+        /// The tag ID for the subscription.
+        /// </summary>
+        public string TagId { get; }
+
+        /// <summary>
+        /// The channel that will emit tag values.
+        /// </summary>
+        private readonly Channel<TagValueQueryResult> _channel = Channel.CreateUnbounded<TagValueQueryResult>();
+
+        /// <summary>
+        /// The channel that will emit tag values.
+        /// </summary>
+        public ChannelReader<TagValueQueryResult> Reader { get { return _channel; } }
+
+
+        /// <summary>
+        /// Creates a new <see cref="SnapshotTagSubscription"/> object.
+        /// </summary>
+        /// <param name="tagId">
+        ///   The tag ID.
+        /// </param>
+        /// <param name="onDisposed">
+        ///   The callback to invoke when the subscription is disposed.
+        /// </param>
+        internal SnapshotTagSubscription(string tagId, Action<SnapshotTagSubscription> onDisposed) {
+            TagId = tagId;
+            _onDisposed = onDisposed;
+        }
+
+
+        /// <summary>
+        /// Writes a value to the <see cref="Reader"/>.
+        /// </summary>
+        /// <param name="value">
+        ///   The value.
+        /// </param>
+        /// <param name="cancellationToken">
+        ///   The cancellation token for the operation.
+        /// </param>
+        /// <returns>
+        ///   A <see cref="ValueTask{TResult}"/> that will return <see langword="true"/> if 
+        ///   the value was written, or <see langword="false"/> otherwise.
+        /// </returns>
+        internal async ValueTask<bool> WriteAsync(TagValueQueryResult value, CancellationToken cancellationToken = default) {
+            if (!await _channel.Writer.WaitToWriteAsync(cancellationToken).ConfigureAwait(false)) {
+                return false;
+            }
+
+            return _channel.Writer.TryWrite(value);
+        }
+
+
+        /// <inheritdoc/>
+        public void Dispose() {
+            if (Interlocked.CompareExchange(ref _isDisposed, 1, 0) != 0) {
+                return;
+            }
+
+            _channel.Writer.TryComplete();
+            _onDisposed?.Invoke(this);
+        }
+
+    }
+}

--- a/src/DataCore.Adapter.AspNetCore.Common/RealTimeData/SnapshotTagSubscription.cs
+++ b/src/DataCore.Adapter.AspNetCore.Common/RealTimeData/SnapshotTagSubscription.cs
@@ -28,7 +28,10 @@ namespace DataCore.Adapter.AspNetCore.RealTimeData {
         /// <summary>
         /// The channel that will emit tag values.
         /// </summary>
-        private readonly Channel<TagValueQueryResult> _channel = Channel.CreateUnbounded<TagValueQueryResult>();
+        private readonly Channel<TagValueQueryResult> _channel = Channel.CreateUnbounded<TagValueQueryResult>(new UnboundedChannelOptions() { 
+            SingleReader = true,
+            SingleWriter = true
+        });
 
         /// <summary>
         /// The channel that will emit tag values.

--- a/src/DataCore.Adapter.AspNetCore.Grpc/Services/TagValuesServiceImpl.cs
+++ b/src/DataCore.Adapter.AspNetCore.Grpc/Services/TagValuesServiceImpl.cs
@@ -1,9 +1,11 @@
 ﻿using System;
+using System.Collections.Concurrent;
 using System.Collections.Generic;
 using System.Linq;
 using System.Threading.Channels;
 using System.Threading.Tasks;
 using DataCore.Adapter.AspNetCore.Grpc;
+using DataCore.Adapter.AspNetCore.RealTimeData;
 using DataCore.Adapter.RealTimeData;
 using Grpc.Core;
 using IntelligentPlant.BackgroundTasks;
@@ -14,6 +16,11 @@ namespace DataCore.Adapter.Grpc.Server.Services {
     /// Implements <see cref="TagValuesService.TagValuesServiceBase"/>.
     /// </summary>
     public class TagValuesServiceImpl : TagValuesService.TagValuesServiceBase {
+
+        /// <summary>
+        /// Holds all active snapshot subscriptions.
+        /// </summary>
+        private static readonly ConcurrentDictionary<string, Task<SnapshotSubscriptionWrapper>> s_snapshotSubscriptions = new ConcurrentDictionary<string, Task<SnapshotSubscriptionWrapper>>();
 
         /// <summary>
         /// The service for resolving adapter references.
@@ -43,78 +50,55 @@ namespace DataCore.Adapter.Grpc.Server.Services {
 
         /// <inheritdoc/>
         public override async Task CreateSnapshotPushChannel(
-            IAsyncStreamReader<CreateSnapshotPushChannelRequest> requestStream, 
+            CreateSnapshotPushChannelRequest request, 
             IServerStreamWriter<TagValueQueryResult> responseStream, 
             ServerCallContext context
         ) {
             var adapterCallContext = new GrpcAdapterCallContext(context);
             var cancellationToken = context.CancellationToken;
 
-            // Wait for first subscription change. We can't actually create our subscription until 
-            // the first change comes in, because we have no way of knowing which adapter to 
-            // actually subscribe to before then.
-
-            if (!await requestStream.MoveNext(cancellationToken).ConfigureAwait(false)) {
-                return;
-            }
-
             var adapter = await Util.ResolveAdapterAndFeature<ISnapshotTagValuePush>(
                 adapterCallContext,
                 _adapterAccessor,
-                requestStream.Current?.AdapterId,
+                request.AdapterId,
                 cancellationToken
             ).ConfigureAwait(false);
 
-            // Create subscription on adapter.
+            var connectionId = adapterCallContext.ConnectionId;
 
-            using (var subscription = await adapter.Feature.Subscribe(adapterCallContext).ConfigureAwait(false)) {
-                if (cancellationToken.IsCancellationRequested) {
+            // Create the subscription.
+            var subscription = await s_snapshotSubscriptions.GetOrAdd(connectionId, k => Task.Run(async () => {
+                var sub = await adapter.Feature.Subscribe(adapterCallContext).ConfigureAwait(false);
+
+                // Register a callback to dispose of the wrapper when the connection is closed.
+
+                var connectionClosedToken = context
+                    .GetHttpContext()
+                    .Features.Get<Microsoft.AspNetCore.Connections.Features.IConnectionLifetimeFeature>()
+                    .ConnectionClosed;
+
+                var wrapper = new SnapshotSubscriptionWrapper(sub, _backgroundTaskService);
+                IDisposable callbackRegistration = null;
+
+                callbackRegistration = connectionClosedToken.Register(() => {
+                    if (s_snapshotSubscriptions.TryRemove(connectionId, out var _)) {
+                        wrapper.Dispose();
+                        callbackRegistration?.Dispose();
+                    }
+                });
+
+                return wrapper;
+            }, cancellationToken)).ConfigureAwait(false);
+
+            using (var tagSubscription = await subscription.AddSubscription(request.Tag).ConfigureAwait(false)) {
+                if (tagSubscription == null) {
                     return;
                 }
 
-                if (requestStream.Current.Action == SubscriptionUpdateAction.Subscribe) {
-                    // Push initial tag subscription change to subscription.
-                    await subscription.AddTagToSubscription(requestStream.Current.Tag).ConfigureAwait(false);
-                }
-
-                // Run background operation to push results back to caller.
-
-                subscription.Reader.RunBackgroundOperation(async (ch, ct) => {
-                    while (!ct.IsCancellationRequested) {
-                        try {
-                            var val = await ch.ReadAsync(ct).ConfigureAwait(false);
-                            if (val == null) {
-                                continue;
-                            }
-
-                            await responseStream.WriteAsync(
-                                val.ToGrpcTagValueQueryResult(TagValueQueryType.SnapshotPush)
-                            ).ConfigureAwait(false);
-                        }
-                        catch (ChannelClosedException) {
-                            break;
-                        }
-                        catch (OperationCanceledException) {
-                            break;
-                        }
-                    }
-                }, _backgroundTaskService, cancellationToken);
-
-                // Now keep pushing new subscription changes to the subscription.
-
-                while (!cancellationToken.IsCancellationRequested) {
-                    try {
-                        await requestStream.MoveNext(cancellationToken).ConfigureAwait(false);
-                        if (requestStream.Current.Action == SubscriptionUpdateAction.Subscribe) {
-                            await subscription.AddTagToSubscription(requestStream.Current.Tag).ConfigureAwait(false);
-                        }
-                        else {
-                            await subscription.RemoveTagFromSubscription(requestStream.Current.Tag).ConfigureAwait(false);
-                        }
-                    }
-                    catch (OperationCanceledException) {
-                        // Do nothing
-                    }
+                await foreach (var value in tagSubscription.Reader.ReadAllAsync(cancellationToken)) {
+                    await responseStream.WriteAsync(
+                        value.ToGrpcTagValueQueryResult(TagValueQueryType.SnapshotPush)
+                    ).ConfigureAwait(false);
                 }
             }
         }

--- a/src/DataCore.Adapter.AspNetCore.SignalR.Client/Clients/TagValuesClient.cs
+++ b/src/DataCore.Adapter.AspNetCore.SignalR.Client/Clients/TagValuesClient.cs
@@ -41,8 +41,8 @@ namespace DataCore.Adapter.AspNetCore.SignalR.Client.Clients {
         /// <param name="adapterId">
         ///   The ID of the adapter to query.
         /// </param>
-        /// <param name="subscriptionChanges">
-        ///   A channel that will publish tags to add to or remove from the subscription.
+        /// <param name="tagIdOrName">
+        ///   The tag ID or name to subscribe to.
         /// </param>
         /// <param name="cancellationToken">
         ///   The cancellation token for the operation. If this token fires, or the connection is
@@ -57,21 +57,21 @@ namespace DataCore.Adapter.AspNetCore.SignalR.Client.Clients {
         /// </exception>
         public async Task<ChannelReader<TagValueQueryResult>> CreateSnapshotTagValueChannelAsync(
             string adapterId, 
-            ChannelReader<UpdateSnapshotTagValueSubscriptionRequest> subscriptionChanges, 
+            string tagIdOrName, 
             CancellationToken cancellationToken = default
         ) {
             if (string.IsNullOrWhiteSpace(adapterId)) {
                 throw new ArgumentException(Resources.Error_ParameterIsRequired, nameof(adapterId));
             }
-            if (subscriptionChanges == null) {
-                throw new ArgumentNullException(nameof(subscriptionChanges));
+            if (string.IsNullOrWhiteSpace(tagIdOrName)) {
+                throw new ArgumentException(Resources.Error_ParameterIsRequired, nameof(tagIdOrName));
             }
 
             var connection = await _client.GetHubConnection(true, cancellationToken).ConfigureAwait(false);
             return await connection.StreamAsChannelAsync<TagValueQueryResult>(
                 "CreateSnapshotTagValueChannel",
                 adapterId,
-                subscriptionChanges,
+                tagIdOrName,
                 cancellationToken
             ).ConfigureAwait(false);
         }

--- a/src/DataCore.Adapter.AspNetCore.SignalR.Proxy/RealTimeData/SnapshotTagValuePushImpl.cs
+++ b/src/DataCore.Adapter.AspNetCore.SignalR.Proxy/RealTimeData/SnapshotTagValuePushImpl.cs
@@ -1,6 +1,8 @@
-﻿using System.Collections.Concurrent;
+﻿using System;
+using System.Collections.Concurrent;
 using System.Linq;
 using System.Threading;
+using System.Threading.Channels;
 using System.Threading.Tasks;
 using DataCore.Adapter.RealTimeData;
 using IntelligentPlant.BackgroundTasks;
@@ -71,6 +73,10 @@ namespace DataCore.Adapter.AspNetCore.SignalR.Proxy.RealTimeData.Features {
             /// <param name="tagId">
             ///   The tag ID.
             /// </param>
+            /// <param name="tcs">
+            ///   A <see cref="TaskCompletionSource{TResult}"/> that will be completed once the 
+            ///   tag subscription has been created.
+            /// </param>
             /// <param name="cancellationToken">
             ///   The cancellation token for the operation.
             /// </param>
@@ -78,12 +84,27 @@ namespace DataCore.Adapter.AspNetCore.SignalR.Proxy.RealTimeData.Features {
             ///   A long-running task that will run the subscription until the cancellation token 
             ///   fires.
             /// </returns>
-            private async Task RunTagSubscription(string tagId, CancellationToken cancellationToken) {
-                var hubChannel = await _push.GetClient().TagValues.CreateSnapshotTagValueChannelAsync(
-                    _push.AdapterId,
-                    tagId,
-                    cancellationToken
-                ).ConfigureAwait(false);
+            private async Task RunTagSubscription(string tagId, TaskCompletionSource<bool> tcs, CancellationToken cancellationToken) {
+                ChannelReader<TagValueQueryResult> hubChannel;
+
+                try {
+                    hubChannel = await _push.GetClient().TagValues.CreateSnapshotTagValueChannelAsync(
+                        _push.AdapterId,
+                        tagId,
+                        cancellationToken
+                    ).ConfigureAwait(false);
+                }
+                catch (OperationCanceledException) {
+                    tcs.TrySetCanceled(cancellationToken);
+                    throw;
+                } 
+                catch (Exception e) {
+                    tcs.TrySetException(e);
+                    throw;
+                }
+                finally {
+                    tcs.TrySetResult(true);
+                }
 
                 await hubChannel.ForEachAsync(async val => {
                     if (val == null) {
@@ -113,7 +134,9 @@ namespace DataCore.Adapter.AspNetCore.SignalR.Proxy.RealTimeData.Features {
                 });
 
                 if (added) {
-                    _push.TaskScheduler.QueueBackgroundWorkItem(ct => RunTagSubscription(tag.Id, ct), ctSource.Token, CancellationToken);
+                    var tcs = new TaskCompletionSource<bool>();
+                    _push.TaskScheduler.QueueBackgroundWorkItem(ct => RunTagSubscription(tag.Id, tcs, ct), ctSource.Token, CancellationToken);
+                    return tcs.Task;
                 }
 
                 return Task.CompletedTask;

--- a/src/DataCore.Adapter.AspNetCore.SignalR/Hubs/AdapterHub.cs
+++ b/src/DataCore.Adapter.AspNetCore.SignalR/Hubs/AdapterHub.cs
@@ -182,5 +182,18 @@ namespace DataCore.Adapter.AspNetCore.Hubs {
             Validator.ValidateObject(instance, new ValidationContext(instance), true);
         }
 
+
+        /// <inheritdoc/>
+        public override Task OnDisconnectedAsync(Exception exception) {
+            OnTagValuesHubDisconnection();
+            return base.OnDisconnectedAsync(exception);
+        }
+
+
+        /// <summary>
+        /// Invoked when a client disconnects.
+        /// </summary>
+        partial void OnTagValuesHubDisconnection();
+
     }
 }

--- a/src/DataCore.Adapter.AspNetCore.SignalR/Hubs/TagValuesHub.cs
+++ b/src/DataCore.Adapter.AspNetCore.SignalR/Hubs/TagValuesHub.cs
@@ -67,7 +67,10 @@ namespace DataCore.Adapter.AspNetCore.Hubs {
                 return new SnapshotSubscriptionWrapper(sub, TaskScheduler);
             }, cancellationToken)).ConfigureAwait(false);
 
-            var result = Channel.CreateUnbounded<TagValueQueryResult>();
+            var result = Channel.CreateUnbounded<TagValueQueryResult>(new UnboundedChannelOptions() { 
+                SingleReader = true,
+                SingleWriter = true
+            });
 
             var tagSubscription = await subscription.AddSubscription(tagIdOrName).ConfigureAwait(false);
 

--- a/src/DataCore.Adapter.AspNetCore.SignalR/Hubs/TagValuesHub.cs
+++ b/src/DataCore.Adapter.AspNetCore.SignalR/Hubs/TagValuesHub.cs
@@ -1,10 +1,11 @@
 ﻿using System;
-using System.Collections.Generic;
-using System.Linq;
+using System.Collections.Concurrent;
 using System.Threading;
 using System.Threading.Channels;
 using System.Threading.Tasks;
+using DataCore.Adapter.AspNetCore.RealTimeData;
 using DataCore.Adapter.RealTimeData;
+using IntelligentPlant.BackgroundTasks;
 
 namespace DataCore.Adapter.AspNetCore.Hubs {
 
@@ -17,13 +18,29 @@ namespace DataCore.Adapter.AspNetCore.Hubs {
         #region [ Snapshot Subscription Management ]
 
         /// <summary>
-        /// Creates a new snapshot push subscription on an adapter.
+        /// Holds all active snapshot subscriptions.
+        /// </summary>
+        private static readonly ConcurrentDictionary<string, Task<SnapshotSubscriptionWrapper>> s_snapshotSubscriptions = new ConcurrentDictionary<string, Task<SnapshotSubscriptionWrapper>>();
+
+
+        /// <summary>
+        /// Invoked when a client disconnects.
+        /// </summary>
+        partial void OnTagValuesHubDisconnection() {
+            if (s_snapshotSubscriptions.TryRemove(Context.ConnectionId, out var s)) {
+                s.Result.Dispose();
+            }
+        }
+
+
+        /// <summary>
+        /// Creates a snapshot tag value subscription.
         /// </summary>
         /// <param name="adapterId">
         ///   The adapter ID.
         /// </param>
-        /// <param name="subscriptionChanges">
-        ///   A channel that subscription changes will be published to.
+        /// <param name="tagIdOrName">
+        ///   The tag ID or name to subscribe to.
         /// </param>
         /// <param name="cancellationToken">
         ///   A cancellation token that will fire when the subscription is no longer required.
@@ -33,63 +50,36 @@ namespace DataCore.Adapter.AspNetCore.Hubs {
         /// </returns>
         public async Task<ChannelReader<TagValueQueryResult>> CreateSnapshotTagValueChannel(
             string adapterId, 
-            ChannelReader<UpdateSnapshotTagValueSubscriptionRequest> subscriptionChanges, 
+            string tagIdOrName, 
             CancellationToken cancellationToken
         ) {
+            if (string.IsNullOrWhiteSpace(tagIdOrName)) {
+                throw new ArgumentException(string.Empty, nameof(tagIdOrName));
+            }
+
             // Resolve the adapter and feature.
             var adapterCallContext = new SignalRAdapterCallContext(Context);
             var adapter = await ResolveAdapterAndFeature<ISnapshotTagValuePush>(adapterCallContext, adapterId, cancellationToken).ConfigureAwait(false);
 
             // Create the subscription.
-            var subscription = await adapter.Feature.Subscribe(adapterCallContext).ConfigureAwait(false);
+            var subscription = await s_snapshotSubscriptions.GetOrAdd(Context.ConnectionId, k => Task.Run(async () => {
+                var sub = await adapter.Feature.Subscribe(adapterCallContext).ConfigureAwait(false);
+                return new SnapshotSubscriptionWrapper(sub, TaskScheduler);
+            }, cancellationToken)).ConfigureAwait(false);
 
             var result = Channel.CreateUnbounded<TagValueQueryResult>();
 
-            // Send a "subscription ready" event so that the caller knows that the stream is 
-            // now up-and-running at this end.
-            var onReady = new TagValueQueryResult(
-                string.Empty,
-                string.Empty,
-                TagValueBuilder
-                    .Create()
-                    .WithValue(subscription.Id)
-                    .Build()
-            );
-            await result.Writer.WriteAsync(onReady);
+            var tagSubscription = await subscription.AddSubscription(tagIdOrName).ConfigureAwait(false);
 
-            // Run background operation to forward values emitted from the subscription.
-            subscription.Reader.RunBackgroundOperation(async (ch, ct) => {
-                while (await ch.WaitToReadAsync(ct).ConfigureAwait(false)) {
-                    if (!ch.TryRead(out var item) || item == null) {
-                        continue;
-                    }
-
-                    await result.Writer.WriteAsync(item, ct).ConfigureAwait(false);
-                }
-            }, TaskScheduler, cancellationToken);
-
-            // Run background operation to push incoming changes to the subscription.
-            subscriptionChanges.RunBackgroundOperation(async (ch, ct) => { 
+            TaskScheduler.QueueBackgroundWorkItem(async ct => { 
                 try {
-                    while (await ch.WaitToReadAsync(ct).ConfigureAwait(false)) {
-                        if (!ch.TryRead(out var item) || item == null) {
-                            continue;
-                        }
-
-                        if (item.Action == Common.SubscriptionUpdateAction.Subscribe) {
-                            await subscription.AddTagToSubscription(item.Tag).ConfigureAwait(false);
-                        }
-                        else {
-                            await subscription.RemoveTagFromSubscription(item.Tag).ConfigureAwait(false);
-                        }
-                    }
+                    await tagSubscription.Reader.Forward(result, ct).ConfigureAwait(false);
                 }
                 finally {
-                    subscription.Dispose();
+                    tagSubscription.Dispose();
                 }
-            }, TaskScheduler, cancellationToken); 
-            
-            // Return the output channel for the subscription.
+            }, cancellationToken);
+
             return result;
         }
 

--- a/src/DataCore.Adapter.Grpc.Proxy/RealTimeData/SnapshotTagValuePushImpl.cs
+++ b/src/DataCore.Adapter.Grpc.Proxy/RealTimeData/SnapshotTagValuePushImpl.cs
@@ -1,7 +1,10 @@
-﻿using System.Threading;
+﻿using System.Collections.Concurrent;
+using System.Linq;
+using System.Threading;
 using System.Threading.Channels;
 using System.Threading.Tasks;
 using DataCore.Adapter.RealTimeData;
+using IntelligentPlant.BackgroundTasks;
 
 namespace DataCore.Adapter.Grpc.Proxy.RealTimeData.Features {
     internal class SnapshotTagValuePushImpl : ProxyAdapterFeature, ISnapshotTagValuePush {
@@ -24,7 +27,21 @@ namespace DataCore.Adapter.Grpc.Proxy.RealTimeData.Features {
         /// </summary>
         private class Subscription : SnapshotTagValueSubscriptionBase {
 
+            /// <summary>
+            /// The feature.
+            /// </summary>
             private readonly SnapshotTagValuePushImpl _push;
+
+            /// <summary>
+            /// The client for the gRPC service.
+            /// </summary>
+            private readonly TagValuesService.TagValuesServiceClient _client;
+
+            /// <summary>
+            /// Holds the lifetime cancellation token for each subscribed tag.
+            /// </summary>
+            private readonly ConcurrentDictionary<string, CancellationTokenSource> _tagSubscriptionLifetimes = new ConcurrentDictionary<string, CancellationTokenSource>();
+
 
             /// <summary>
             /// Creates a new <see cref="Subscription"/>.
@@ -40,49 +57,36 @@ namespace DataCore.Adapter.Grpc.Proxy.RealTimeData.Features {
                 SnapshotTagValuePushImpl push
             ) : base(context, push.AdapterId) {
                 _push = push;
+                _client = _push.CreateClient<TagValuesService.TagValuesServiceClient>();
             }
 
 
-            /// <inheritdoc/>
-            protected override async Task RunSubscription(ChannelReader<SnapshotTagValueSubscriptionChange> channel, CancellationToken cancellationToken) {
-                var client = _push.CreateClient<TagValuesService.TagValuesServiceClient>();
-                var duplexCall = client.CreateSnapshotPushChannel(_push.GetCallOptions(Context, cancellationToken));
+            /// <summary>
+            /// Creates an processes a subscription to the specified tag ID.
+            /// </summary>
+            /// <param name="tagId">
+            ///   The tag ID.
+            /// </param>
+            /// <param name="cancellationToken">
+            ///   The cancellation token for the operation.
+            /// </param>
+            /// <returns>
+            ///   A long-running task that will run the subscription until the cancellation token 
+            ///   fires.
+            /// </returns>
+            private async Task RunTagSubscription(string tagId, CancellationToken cancellationToken) {
+                var grpcChannel = _client.CreateSnapshotPushChannel(new CreateSnapshotPushChannelRequest() { 
+                    AdapterId = _push.AdapterId,
+                    Tag = tagId
+                }, _push.GetCallOptions(Context, cancellationToken));
 
-                // Run another background task to read subscription changes and pass them to the 
-                // remote service.
-                channel.RunBackgroundOperation(async (ch, ct) => {
-                    while (await ch.WaitToReadAsync(ct).ConfigureAwait(false)) {
-                        if (!ch.TryRead(out var change) || change == null) {
-                            continue;
-                        }
-
-                        try {
-                            await duplexCall.RequestStream.WriteAsync(
-                                new CreateSnapshotPushChannelRequest() {
-                                    AdapterId = _push.AdapterId,
-                                    Tag = change.Request.Tag ?? string.Empty,
-                                    Action = change.Request.Action == Common.SubscriptionUpdateAction.Subscribe
-                                        ? SubscriptionUpdateAction.Subscribe
-                                        : SubscriptionUpdateAction.Unsubscribe
-                                }
-                            ).ConfigureAwait(false);
-                            change.SetResult(true);
-                        }
-                        catch {
-                            change.SetResult(false);
-                            throw;
-                        }
-                    }
-                }, _push.TaskScheduler, cancellationToken);
-
-                // Read value changes.
-                while (await duplexCall.ResponseStream.MoveNext(cancellationToken).ConfigureAwait(false)) {
-                    if (duplexCall.ResponseStream.Current == null) {
+                while (await grpcChannel.ResponseStream.MoveNext(cancellationToken).ConfigureAwait(false)) {
+                    if (grpcChannel.ResponseStream.Current == null) {
                         continue;
                     }
 
                     await ValueReceived(
-                        duplexCall.ResponseStream.Current.ToAdapterTagValueQueryResult(), 
+                        grpcChannel.ResponseStream.Current.ToAdapterTagValueQueryResult(),
                         cancellationToken
                     ).ConfigureAwait(false);
                 }
@@ -97,13 +101,49 @@ namespace DataCore.Adapter.Grpc.Proxy.RealTimeData.Features {
 
             /// <inheritdoc/>
             protected override Task OnTagAdded(Adapter.RealTimeData.TagIdentifier tag) {
+                if (CancellationToken.IsCancellationRequested) {
+                    return Task.CompletedTask;
+                }
+
+                var added = false;
+                var ctSource = _tagSubscriptionLifetimes.GetOrAdd(tag.Id, k => {
+                    added = true;
+                    return new CancellationTokenSource();
+                });
+
+                if (added) {
+                    _push.TaskScheduler.QueueBackgroundWorkItem(ct => RunTagSubscription(tag.Id, ct), ctSource.Token, CancellationToken);
+                }
+
                 return Task.CompletedTask;
             }
 
 
             /// <inheritdoc/>
             protected override Task OnTagRemoved(Adapter.RealTimeData.TagIdentifier tag) {
+                if (CancellationToken.IsCancellationRequested) {
+                    return Task.CompletedTask;
+                }
+
+                if (_tagSubscriptionLifetimes.TryRemove(tag.Id, out var ctSource)) {
+                    ctSource.Cancel();
+                    ctSource.Dispose();
+                }
+
                 return Task.CompletedTask;
+            }
+
+
+            /// <inheritdoc/>
+            protected override void OnCancelled() {
+                base.OnCancelled();
+
+                foreach (var item in _tagSubscriptionLifetimes.Values.ToArray()) {
+                    item.Cancel();
+                    item.Dispose();
+                }
+
+                _tagSubscriptionLifetimes.Clear();
             }
 
         }

--- a/src/DataCore.Adapter.Json/DataCore.Adapter.Json.csproj
+++ b/src/DataCore.Adapter.Json/DataCore.Adapter.Json.csproj
@@ -1,7 +1,7 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <TargetFramework>netstandard2.0</TargetFramework>
+    <TargetFrameworks>netstandard2.0</TargetFrameworks>
     <RootNamespace>DataCore.Adapter.Json</RootNamespace>
     <PackageId>$(PackagePrefix).Adapter.Json</PackageId>
     <Description>System.Text.Json extensions for App Store Connect adapters.</Description>

--- a/src/Protos/datacore/adapter/TagValuesService.proto
+++ b/src/Protos/datacore/adapter/TagValuesService.proto
@@ -12,7 +12,7 @@ option csharp_namespace = "DataCore.Adapter.Grpc";
 service TagValuesService {
     // Snapshot polling/push
     rpc ReadSnapshotTagValues (ReadSnapshotTagValuesRequest) returns (stream TagValueQueryResult);
-    rpc CreateSnapshotPushChannel (stream CreateSnapshotPushChannelRequest) returns (stream TagValueQueryResult);
+    rpc CreateSnapshotPushChannel (CreateSnapshotPushChannelRequest) returns (stream TagValueQueryResult);
 
     
     // Historical data polling
@@ -40,7 +40,6 @@ message ReadSnapshotTagValuesRequest {
 message CreateSnapshotPushChannelRequest {
     string adapter_id = 1;
     string tag = 2;
-    SubscriptionUpdateAction action = 3;
 }
 
 


### PR DESCRIPTION
This PR refactors the way that gRPC and SignalR endpoints handle tag value subscriptions.

Previously, both endpoints used bi-directional streaming, with the client-to-server stream being used to push subscription changes to the server ("add tag X", "remove tag Y", etc). This made things unnecessarily complicated, and resulted in side-effects such as the gRPC call returning immediately on the client-side, but not starting on the server side until the first item was written to the client-to-server stream.

This PR changes the behaviour of both endpoint types so that the calls are now just uni-directional server-to-client steaming methods, with each invocation returning values for a single tag. On the server-side, logic has been added to create and manage subscriptions for individual adapters, and to dispose of these underlying subscriptions when the gRPC or SignalR connection is closed.

**Note that this is a breaking change to existing gRPC and SignalR hosts and clients**