### PR TITLE
Topic-based event subscriptions + gRPC request properties

### DIFF
--- a/src/DataCore.Adapter.Abstractions/Events/IEventMessagePushWithTopics.cs
+++ b/src/DataCore.Adapter.Abstractions/Events/IEventMessagePushWithTopics.cs
@@ -1,0 +1,33 @@
+﻿using System.Threading.Tasks;
+
+namespace DataCore.Adapter.Events {
+
+    /// <summary>
+    /// Feature for subscribing to receive event messages from an adapter for specific topics via 
+    /// a push notification.
+    /// </summary>
+    public interface IEventMessagePushWithTopics : IAdapterFeature {
+
+        /// <summary>
+        /// Creates a push subscription.
+        /// </summary>
+        /// <param name="context">
+        ///   The <see cref="IAdapterCallContext"/> for the caller.
+        /// </param>
+        /// <param name="request">
+        ///   A request specifying parameters for the subscription, such as whether a passive or 
+        ///   active subscription should be created. Some adapters will only emit event messages 
+        ///   when they have at least one active subscriber.
+        /// </param>
+        /// <returns>
+        ///   A task that will create and start a subscription object that can be disposed once 
+        ///   the subscription is no longer required.
+        /// </returns>
+        Task<IEventMessageSubscriptionWithTopics> Subscribe(
+            IAdapterCallContext context,
+            CreateEventMessageSubscriptionRequest request
+        );
+
+    }
+
+}

--- a/src/DataCore.Adapter.Abstractions/Events/IEventMessageSubscriptionWithTopics.cs
+++ b/src/DataCore.Adapter.Abstractions/Events/IEventMessageSubscriptionWithTopics.cs
@@ -1,0 +1,8 @@
+﻿
+namespace DataCore.Adapter.Events {
+    /// <summary>
+    /// Defines a subscription for receiving event messages for specific topics as push 
+    /// notifications.
+    /// </summary>
+    public interface IEventMessageSubscriptionWithTopics : IAdapterSubscriptionWithTopics<EventMessage> { }
+}

--- a/src/DataCore.Adapter.Abstractions/README.md
+++ b/src/DataCore.Adapter.Abstractions/README.md
@@ -26,6 +26,7 @@ Adapters can define any number of the following standard features:
     - [IHealthCheck](./Diagostics/IHealthCheck.cs)
 - Events:
     - [IEventMessagePush](./Events/IEventMessagePush.cs)
+    - [IEventMessagePushWithTopics](./Events/IEventMessagePushWithTopics.cs)
     - [IReadEventMessagesForTimeRange](./Events/IReadEventMessagesForTimeRange.cs)
     - [IReadEventMessagesUsingCursor](./Events/IReadEventMessagesUsingCursor.cs)
     - [IWriteEventMessages](./Events/IWriteEventMessages.cs)

--- a/src/DataCore.Adapter.AspNetCore.Grpc/GrpcExtensions.cs
+++ b/src/DataCore.Adapter.AspNetCore.Grpc/GrpcExtensions.cs
@@ -900,6 +900,7 @@ namespace DataCore.Adapter {
 
             return Events.EventMessage.Create(
                 message.Id,
+                message.Topic,
                 message.UtcEventTime.ToDateTime(),
                 message.Priority.ToAdapterEventPriority(),
                 message.Category,
@@ -926,6 +927,7 @@ namespace DataCore.Adapter {
             var result = new Grpc.EventMessage() {
                 Category = message.Category ?? string.Empty,
                 Id = message.Id ?? string.Empty,
+                Topic = message.Topic ?? string.Empty,
                 Message = message.Message ?? string.Empty,
                 Priority = message.Priority.ToGrpcEventPriority(),
                 UtcEventTime = Google.Protobuf.WellKnownTypes.Timestamp.FromDateTime(message.UtcEventTime)
@@ -960,6 +962,7 @@ namespace DataCore.Adapter {
 
             return Events.EventMessageWithCursorPosition.Create(
                 message.EventMessage.Id,
+                message.EventMessage.Topic,
                 message.EventMessage.UtcEventTime.ToDateTime(),
                 message.EventMessage.Priority.ToAdapterEventPriority(),
                 message.EventMessage.Category,
@@ -986,7 +989,7 @@ namespace DataCore.Adapter {
 
             var result = new Grpc.EventMessageWithCursorPosition() {
                 CursorPosition = message.CursorPosition,
-                EventMessage = ToGrpcEventMessage((Events.EventMessageBase) message)
+                EventMessage = ToGrpcEventMessage(message)
             };
 
             return result;
@@ -1011,6 +1014,7 @@ namespace DataCore.Adapter {
                 CorrelationId = writeRequest.CorrelationId,
                 EventMessage = Events.EventMessage.Create(
                     writeRequest.Message?.Id,
+                    writeRequest.Message?.Topic,
                     writeRequest.Message?.UtcEventTime?.ToDateTime() ?? DateTime.MinValue,
                     writeRequest.Message?.Priority.ToAdapterEventPriority() ?? Events.EventPriority.Unknown,
                     writeRequest.Message?.Category,

--- a/src/DataCore.Adapter.AspNetCore.Grpc/Services/AssetModelBrowserServiceImpl.cs
+++ b/src/DataCore.Adapter.AspNetCore.Grpc/Services/AssetModelBrowserServiceImpl.cs
@@ -1,4 +1,5 @@
-﻿using System.Linq;
+﻿using System.Collections.Generic;
+using System.Linq;
 using System.Threading.Tasks;
 using DataCore.Adapter.AspNetCore.Grpc;
 using DataCore.Adapter.AssetModel;
@@ -40,7 +41,8 @@ namespace DataCore.Adapter.Grpc.Server.Services {
                     ? null 
                     : request.ParentId,
                 PageSize = request.PageSize,
-                Page = request.Page
+                Page = request.Page,
+                Properties = new Dictionary<string, string>(request.Properties)
             };
             Util.ValidateObject(adapterRequest);
 
@@ -64,7 +66,8 @@ namespace DataCore.Adapter.Grpc.Server.Services {
             var adapter = await Util.ResolveAdapterAndFeature<IAssetModelBrowse>(adapterCallContext, _adapterAccessor, adapterId, cancellationToken).ConfigureAwait(false);
 
             var adapterRequest = new Adapter.AssetModel.GetAssetModelNodesRequest() {
-                Nodes = request.Nodes.ToArray()
+                Nodes = request.Nodes.ToArray(),
+                Properties = new Dictionary<string, string>(request.Properties)
             };
             Util.ValidateObject(adapterRequest);
 
@@ -91,7 +94,8 @@ namespace DataCore.Adapter.Grpc.Server.Services {
                 Name = request.Name,
                 Description = request.Description,
                 PageSize = request.PageSize,
-                Page = request.Page
+                Page = request.Page,
+                Properties = new Dictionary<string, string>(request.Properties)
             };
             Util.ValidateObject(adapterRequest);
 

--- a/src/DataCore.Adapter.AspNetCore.Grpc/Services/EventsServiceImpl.cs
+++ b/src/DataCore.Adapter.AspNetCore.Grpc/Services/EventsServiceImpl.cs
@@ -1,6 +1,11 @@
 ﻿using System;
 using System.Collections.Generic;
+using System.Linq;
+using System.Threading;
+using System.Threading.Channels;
 using System.Threading.Tasks;
+
+using DataCore.Adapter.AspNetCore;
 using DataCore.Adapter.AspNetCore.Grpc;
 using DataCore.Adapter.Events;
 using Grpc.Core;
@@ -14,6 +19,16 @@ namespace DataCore.Adapter.Grpc.Server.Services {
     public class EventsServiceImpl : EventsService.EventsServiceBase {
 
         /// <summary>
+        /// Holds all active subscriptions.
+        /// </summary>
+        private static readonly ConnectionSubscriptionManager<Events.EventMessage, TopicSubscriptionWrapper<Events.EventMessage>> s_eventTopicSubscriptions = new ConnectionSubscriptionManager<Events.EventMessage, TopicSubscriptionWrapper<Events.EventMessage>>();
+
+        /// <summary>
+        /// Indicates if the background cleanup task is running.
+        /// </summary>
+        private static int s_cleanupTaskIsRunning;
+
+        /// <summary>
         /// The service for resolving adapter references.
         /// </summary>
         private readonly IAdapterAccessor _adapterAccessor;
@@ -22,6 +37,20 @@ namespace DataCore.Adapter.Grpc.Server.Services {
         /// The service for registering background task operations.
         /// </summary>
         private readonly IBackgroundTaskService _backgroundTaskService;
+
+
+        /// <summary>
+        /// Class initialiser.
+        /// </summary>
+        static EventsServiceImpl() {
+            AspNetCore.Grpc.Services.HeartbeatServiceImpl.HeartbeatReceived += peer => {
+                if (string.IsNullOrWhiteSpace(peer)) {
+                    return;
+                }
+
+                s_eventTopicSubscriptions.SetHeartbeat(peer, DateTime.UtcNow);
+            };
+        }
 
 
         /// <summary>
@@ -39,7 +68,45 @@ namespace DataCore.Adapter.Grpc.Server.Services {
         }
 
 
-        /// <inheritdoc/>
+        /// <summary>
+        /// Periodically removes all subscriptions for any connections that have not sent a recent
+        /// heartbeat message.
+        /// </summary>
+        /// <param name="timeout">
+        ///   The heartbeat timeout.
+        /// </param>
+        internal static void CleanUpStaleSubscriptions(TimeSpan timeout) {
+            foreach (var connectionId in s_eventTopicSubscriptions.GetConnectionIds()) {
+                if (!s_eventTopicSubscriptions.IsConnectionStale(connectionId, timeout)) {
+                    continue;
+                }
+
+                s_eventTopicSubscriptions.RemoveAllSubscriptions(connectionId);
+            }
+        }
+
+
+        /// <summary>
+        /// Creates a general event message subscription to an adapter using the adapter's 
+        /// <see cref="IEventMessagePush"/> feature. For topic-based event streams, see 
+        /// <see cref="CreateEventTopicPushSubscription"/>.
+        /// </summary>
+        /// <param name="request">
+        ///   The request.
+        /// </param>
+        /// <param name="responseStream">
+        ///   The response stream to write event messages to.
+        /// </param>
+        /// <param name="context">
+        ///   The call context.
+        /// </param>
+        /// <returns>
+        ///   A <see cref="Task"/> that will publish emitted event messages to the 
+        ///   <paramref name="responseStream"/>.
+        /// </returns>
+        /// <seealso cref="CreateEventTopicPushSubscription"/>
+        /// <seealso cref="DeleteEventTopicPushSubscription"/>
+        /// <seealso cref="CreateEventTopicPushChannel"/>
         public override async Task CreateEventPushChannel(CreateEventPushChannelRequest request, IServerStreamWriter<EventMessage> responseStream, ServerCallContext context) {
             var adapterCallContext = new GrpcAdapterCallContext(context);
             var adapterId = request.AdapterId;
@@ -49,7 +116,8 @@ namespace DataCore.Adapter.Grpc.Server.Services {
             using (var subscription = await adapter.Feature.Subscribe(adapterCallContext, new CreateEventMessageSubscriptionRequest() { 
                 SubscriptionType = request.SubscriptionType == EventSubscriptionType.Active 
                     ? EventMessageSubscriptionType.Active 
-                    : EventMessageSubscriptionType.Passive
+                    : EventMessageSubscriptionType.Passive,
+                Properties = new Dictionary<string, string>(request.Properties)
             }).ConfigureAwait(false)) {
                 while (!cancellationToken.IsCancellationRequested) {
                     try {
@@ -59,10 +127,160 @@ namespace DataCore.Adapter.Grpc.Server.Services {
                     catch (OperationCanceledException) {
                         // Do nothing
                     }
-                    catch (System.Threading.Channels.ChannelClosedException) { 
+                    catch (ChannelClosedException) { 
                         // Do nothing
                     }
                 }
+            }
+        }
+
+
+        /// <summary>
+        /// Creates a topic-based event subscription for an adapter using the adapter's 
+        /// <see cref="IEventMessagePushWithTopics"/> feature. Note that this does not add any 
+        /// event topics to the subscription; this must be done separately via calls to 
+        /// <see cref="CreateEventTopicPushChannel"/>.
+        /// </summary>
+        /// <param name="request">
+        ///   The request.
+        /// </param>
+        /// <param name="context">
+        ///   The call context.
+        /// </param>
+        /// <returns>
+        ///   A <see cref="Task{TResult}"/> that will return the response for the operation.
+        /// </returns>
+        public override async Task<CreateEventTopicPushSubscriptionResponse> CreateEventTopicPushSubscription(
+            CreateEventTopicPushSubscriptionRequest request, 
+            ServerCallContext context
+        ) {
+            if (Interlocked.CompareExchange(ref s_cleanupTaskIsRunning, 1, 0) == 0) {
+                // Kick off background cleanup of stale subscriptions.
+                _backgroundTaskService.QueueBackgroundWorkItem(async ct => {
+                    try {
+                        var checkInterval = TimeSpan.FromSeconds(10);
+                        var staleTimeout = TimeSpan.FromSeconds(30);
+
+                        while (!ct.IsCancellationRequested) {
+                            await Task.Delay(checkInterval, ct).ConfigureAwait(false);
+                            CleanUpStaleSubscriptions(staleTimeout);
+                        }
+                    }
+                    finally {
+                        s_cleanupTaskIsRunning = 0;
+                    }
+                });
+            }
+
+            var adapterCallContext = new GrpcAdapterCallContext(context);
+            var cancellationToken = context.CancellationToken;
+            var adapterId = request.AdapterId;
+            var connectionId = string.IsNullOrWhiteSpace(request.SessionId)
+                ? context.Peer
+                : string.Concat(context.Peer, "-", request.SessionId);
+
+            var adapter = await Util.ResolveAdapterAndFeature<IEventMessagePushWithTopics>(
+                adapterCallContext,
+                _adapterAccessor,
+                adapterId,
+                cancellationToken
+            ).ConfigureAwait(false);
+
+#pragma warning disable CA2000 // Dispose objects before losing scope
+            var wrappedSubscription = new TopicSubscriptionWrapper<Events.EventMessage>(
+                await adapter.Feature.Subscribe(adapterCallContext, new CreateEventMessageSubscriptionRequest() {
+                    SubscriptionType = request.SubscriptionType == EventSubscriptionType.Active
+                        ? EventMessageSubscriptionType.Active
+                        : EventMessageSubscriptionType.Passive,
+                    Properties = new Dictionary<string, string>(request.Properties)
+                }).ConfigureAwait(false),
+                _backgroundTaskService
+            );
+#pragma warning restore CA2000 // Dispose objects before losing scope
+
+            return new CreateEventTopicPushSubscriptionResponse() {
+                SubscriptionId = s_eventTopicSubscriptions.AddSubscription(connectionId, wrappedSubscription)
+            };
+        }
+
+
+        /// <summary>
+        /// Deletes a topic-based event subscription that was created via a call to 
+        /// <see cref="CreateEventTopicPushSubscription"/>.
+        /// </summary>
+        /// <param name="request">
+        ///   The request.
+        /// </param>
+        /// <param name="context">
+        ///   The call context.
+        /// </param>
+        /// <returns>
+        ///   A <see cref="Task{TResult}"/> that will return the response for the operation.
+        /// </returns>
+        public override Task<DeleteEventTopicPushSubscriptionResponse> DeleteEventTopicPushSubscription(
+            DeleteEventTopicPushSubscriptionRequest request, 
+            ServerCallContext context
+        ) {
+            DeleteEventTopicPushSubscriptionResponse result;
+
+            var connectionId = string.IsNullOrWhiteSpace(request.SessionId)
+                ? context.Peer
+                : string.Concat(context.Peer, "-", request.SessionId);
+
+            if (string.IsNullOrWhiteSpace(request.SubscriptionId)) {
+                s_eventTopicSubscriptions.RemoveAllSubscriptions(connectionId);
+                result = new DeleteEventTopicPushSubscriptionResponse() {
+                    Success = true
+                };
+            }
+            else {
+                result = new DeleteEventTopicPushSubscriptionResponse() {
+                    Success = s_eventTopicSubscriptions.RemoveSubscription(connectionId, request.SubscriptionId)
+                };
+            }
+            return Task.FromResult(result);
+        }
+
+
+        /// <summary>
+        /// Adds a topic to a topic-based event subscription and streams emitted messages to the 
+        /// caller. Subscriptions are created via calls to <see cref="CreateEventTopicPushSubscription"/>.
+        /// </summary>
+        /// <param name="request">
+        ///   The request.
+        /// </param>
+        /// <param name="responseStream">
+        ///   The response stream to write event messages to.
+        /// </param>
+        /// <param name="context">
+        ///   The call context.
+        /// </param>
+        /// <returns>
+        ///   A <see cref="Task"/> that will publish emitted event messages to the 
+        ///   <paramref name="responseStream"/>.
+        /// </returns>
+        public override async Task CreateEventTopicPushChannel(CreateEventTopicPushChannelRequest request, IServerStreamWriter<EventMessage> responseStream, ServerCallContext context) {
+            var connectionId = string.IsNullOrWhiteSpace(request.SessionId)
+                ? context.Peer
+                : string.Concat(context.Peer, "-", request.SessionId);
+
+            var cancellationToken = context.CancellationToken;
+
+            if (!s_eventTopicSubscriptions.TryGetSubscription(connectionId, request.SubscriptionId, out var subscription)) {
+                return;
+            }
+
+            var channel = await subscription.CreateTopicChannel(request.Topic).ConfigureAwait(false);
+            try {
+                await foreach (var val in channel.Reader.ReadAllAsync(cancellationToken).ConfigureAwait(false)) {
+                    await responseStream.WriteAsync(val.ToGrpcEventMessage()).ConfigureAwait(false);
+                }
+            }
+            catch (OperationCanceledException) {
+                // Caller has cancelled the subscription.
+            }
+            catch (ChannelClosedException) {
+                // Channel has been closed due to the connection being terminated.
             }
         }
 
@@ -81,7 +299,9 @@ namespace DataCore.Adapter.Grpc.Server.Services {
                 Page = request.Page,
                 Direction = request.Direction == EventReadDirection.Forwards
                     ? Events.EventReadDirection.Forwards
-                    : Events.EventReadDirection.Backwards
+                    : Events.EventReadDirection.Backwards,
+                Topics = request.Topics.ToArray(),
+                Properties = new Dictionary<string, string>(request.Properties)
             };
             Util.ValidateObject(adapterRequest);
 
@@ -109,7 +329,9 @@ namespace DataCore.Adapter.Grpc.Server.Services {
                 PageSize = request.PageSize,
                 Direction = request.Direction == EventReadDirection.Forwards
                     ? Events.EventReadDirection.Forwards
-                    : Events.EventReadDirection.Backwards
+                    : Events.EventReadDirection.Backwards,
+                Topics = request.Topics.ToArray(),
+                Properties = new Dictionary<string, string>(request.Properties)
             };
             Util.ValidateObject(adapterRequest);
 

--- a/src/DataCore.Adapter.AspNetCore.Grpc/Services/TagSearchServiceImpl.cs
+++ b/src/DataCore.Adapter.AspNetCore.Grpc/Services/TagSearchServiceImpl.cs
@@ -1,4 +1,5 @@
-﻿using System.Linq;
+﻿using System.Collections.Generic;
+using System.Linq;
 using System.Threading.Tasks;
 using DataCore.Adapter.AspNetCore.Grpc;
 using DataCore.Adapter.RealTimeData;
@@ -37,7 +38,8 @@ namespace DataCore.Adapter.Grpc.Server.Services {
 
             var adapterRequest = new Adapter.RealTimeData.GetTagPropertiesRequest() {
                 PageSize = request.PageSize,
-                Page = request.Page
+                Page = request.Page,
+                Properties = new Dictionary<string, string>(request.Properties)
             };
             Util.ValidateObject(adapterRequest);
 
@@ -67,7 +69,8 @@ namespace DataCore.Adapter.Grpc.Server.Services {
                 Label = request.Label,
                 Other = request.Other,
                 PageSize = request.PageSize,
-                Page = request.Page
+                Page = request.Page,
+                Properties = new Dictionary<string, string>(request.Properties)
             };
             Util.ValidateObject(adapterRequest);
 
@@ -91,7 +94,8 @@ namespace DataCore.Adapter.Grpc.Server.Services {
             var adapter = await Util.ResolveAdapterAndFeature<ITagInfo>(adapterCallContext, _adapterAccessor, adapterId, cancellationToken).ConfigureAwait(false);
 
             var adapterRequest = new Adapter.RealTimeData.GetTagsRequest() {
-                Tags = request.Tags.ToArray()
+                Tags = request.Tags.ToArray(),
+                Properties = new Dictionary<string, string>(request.Properties)
             };
             Util.ValidateObject(adapterRequest);
 

--- a/src/DataCore.Adapter.AspNetCore.Grpc/Services/TagValueAnnotationsServiceImpl.cs
+++ b/src/DataCore.Adapter.AspNetCore.Grpc/Services/TagValueAnnotationsServiceImpl.cs
@@ -1,4 +1,5 @@
 ﻿using System;
+using System.Collections.Generic;
 using System.Linq;
 using System.Threading.Tasks;
 using DataCore.Adapter.AspNetCore.Grpc;
@@ -39,7 +40,9 @@ namespace DataCore.Adapter.Grpc.Server.Services {
             var adapterRequest = new RealTimeData.ReadAnnotationsRequest() {
                 UtcStartTime = request.UtcStartTime.ToDateTime(),
                 UtcEndTime = request.UtcEndTime.ToDateTime(),
-                Tags = request.Tags?.ToArray() ?? Array.Empty<string>()
+                Tags = request.Tags?.ToArray() ?? Array.Empty<string>(),
+                AnnotationCount = request.MaxAnnotationCount,
+                Properties = request.Properties
             };
             Util.ValidateObject(adapterRequest);
 
@@ -64,7 +67,8 @@ namespace DataCore.Adapter.Grpc.Server.Services {
 
             var adapterRequest = new RealTimeData.ReadAnnotationRequest() {
                 Tag = request.Tag,
-                AnnotationId = request.AnnotationId
+                AnnotationId = request.AnnotationId,
+                Properties = new Dictionary<string, string>(request.Properties)
             };
             Util.ValidateObject(adapterRequest);
 
@@ -82,7 +86,8 @@ namespace DataCore.Adapter.Grpc.Server.Services {
 
             var adapterRequest = new RealTimeData.CreateAnnotationRequest() {
                 Tag = request.Tag,
-                Annotation = request.Annotation.ToAdapterTagValueAnnotation()
+                Annotation = request.Annotation.ToAdapterTagValueAnnotation(),
+                Properties = new Dictionary<string, string>(request.Properties)
             };
             Util.ValidateObject(adapterRequest);
 
@@ -101,7 +106,8 @@ namespace DataCore.Adapter.Grpc.Server.Services {
             var adapterRequest = new RealTimeData.UpdateAnnotationRequest() {
                 Tag = request.Tag,
                 AnnotationId = request.AnnotationId,
-                Annotation = request.Annotation.ToAdapterTagValueAnnotation()
+                Annotation = request.Annotation.ToAdapterTagValueAnnotation(),
+                Properties = new Dictionary<string, string>(request.Properties)
             };
             Util.ValidateObject(adapterRequest);
 
@@ -119,7 +125,8 @@ namespace DataCore.Adapter.Grpc.Server.Services {
 
             var adapterRequest = new RealTimeData.DeleteAnnotationRequest() {
                 Tag = request.Tag,
-                AnnotationId = request.AnnotationId
+                AnnotationId = request.AnnotationId,
+                Properties = new Dictionary<string, string>(request.Properties)
             };
             Util.ValidateObject(adapterRequest);
 

--- a/src/DataCore.Adapter.AspNetCore.SignalR.Client/Clients/EventsClient.cs
+++ b/src/DataCore.Adapter.AspNetCore.SignalR.Client/Clients/EventsClient.cs
@@ -33,8 +33,7 @@ namespace DataCore.Adapter.AspNetCore.SignalR.Client.Clients {
 
 
         /// <summary>
-        /// Creates a subscription channel to receive event messages in real-time from the 
-        /// specified adapter.
+        /// Creates a channel to receive event messages in real-time from the specified adapter.
         /// </summary>
         /// <param name="adapterId">
         ///   The ID of the adapter to query.
@@ -47,8 +46,8 @@ namespace DataCore.Adapter.AspNetCore.SignalR.Client.Clients {
         ///   lost, the channel will be closed.
         /// </param>
         /// <returns>
-        ///   A task that will return a channel that is used to stream the event messages back to 
-        ///   the caller.
+        ///   A <see cref="Task{TResult}"/> that will return a channel that is used to stream the 
+        ///   event messages back to the caller.
         /// </returns>
         /// <exception cref="ArgumentException">
         ///   <paramref name="adapterId"/> is <see langword="null"/> or white space.
@@ -63,6 +62,108 @@ namespace DataCore.Adapter.AspNetCore.SignalR.Client.Clients {
                 "CreateEventMessageChannel",
                 adapterId,
                 request,
+                cancellationToken
+            ).ConfigureAwait(false);
+        }
+
+
+        /// <summary>
+        /// Creates a topic-based event subscription that can be used to subscribe to specific 
+        /// event topics on an adapter.
+        /// </summary>
+        /// <param name="adapterId">
+        ///   The adapter ID.
+        /// </param>
+        /// <param name="request">
+        ///   Additional subscription properties.
+        /// </param>
+        /// <param name="cancellationToken">
+        ///   The cancellation token for the operation.
+        /// </param>
+        /// <returns>
+        ///   A <see cref="Task{TResult}"/> that will return the subscription ID.
+        /// </returns>
+        /// <seealso cref="DeleteEventMessageTopicSubscriptionAsync"/>
+        /// <seealso cref="CreateEventMessageTopicChannelAsync"/>
+        public async Task<string> CreateEventMessageTopicSubscriptionAsync(string adapterId, CreateEventMessageSubscriptionRequest request, CancellationToken cancellationToken) {
+            if (string.IsNullOrWhiteSpace(adapterId)) {
+                throw new ArgumentException(Resources.Error_ParameterIsRequired, nameof(adapterId));
+            }
+
+            var connection = await _client.GetHubConnection(true, cancellationToken).ConfigureAwait(false);
+            return await connection.InvokeAsync<string>(
+                "CreateEventMessageTopicSubscription",
+                adapterId,
+                request,
+                cancellationToken
+            ).ConfigureAwait(false);
+        }
+
+
+        /// <summary>
+        /// Deletes a topic-based event subscription that was created via a call to 
+        /// <see cref="CreateEventMessageTopicSubscriptionAsync"/>.
+        /// </summary>
+        /// <param name="subscriptionId">
+        ///   The subscription ID. Specify <see langword="null"/> or white space to delete all active 
+        ///   event topic subscriptions for the connection.
+        /// </param>
+        /// <param name="cancellationToken">
+        ///   The cancellation token for the operation.
+        /// </param>
+        /// <returns>
+        ///   A <see cref="Task{TResult}"/> that returns a flag indicating if the operation was 
+        ///   successful.
+        /// </returns>
+        /// <seealso cref="CreateEventMessageTopicSubscriptionAsync"/>
+        /// <seealso cref="CreateEventMessageTopicChannelAsync"/>
+        public async Task<bool> DeleteEventMessageTopicSubscriptionAsync(string subscriptionId, CancellationToken cancellationToken) {
+            if (string.IsNullOrWhiteSpace(subscriptionId)) {
+                throw new ArgumentException(Resources.Error_ParameterIsRequired, nameof(subscriptionId));
+            }
+
+            var connection = await _client.GetHubConnection(true, cancellationToken).ConfigureAwait(false);
+            return await connection.InvokeAsync<bool>(
+                "DeleteEventMessageTopicSubscription",
+                subscriptionId,
+                cancellationToken
+            ).ConfigureAwait(false);
+        }
+
+
+        /// <summary>
+        /// Creates a channel to receive event messages in real-time from a topic-based event 
+        /// subscription created via a call to <see cref="CreateEventMessageTopicSubscriptionAsync"/>.
+        /// </summary>
+        /// <param name="subscriptionId">
+        ///   The subscription ID.
+        /// </param>
+        /// <param name="topic">
+        ///   The event topic to subscribe to.
+        /// </param>
+        /// <param name="cancellationToken">
+        ///   The cancellation token for the operation. If this token fires, or the connection is
+        ///   lost, the channel will be closed.
+        /// </param>
+        /// <returns>
+        ///   A <see cref="Task{TResult}"/> that will return a channel that is used to stream the 
+        ///   event messages back to the caller.
+        /// </returns>
+        /// <seealso cref="CreateEventMessageTopicSubscriptionAsync"/>
+        /// <seealso cref="CreatDeleteEventMessageTopicSubscriptionAsync"/>
+        public async Task<ChannelReader<EventMessage>> CreateEventMessageTopicChannelAsync(string subscriptionId, string topic, CancellationToken cancellationToken) {
+            if (string.IsNullOrWhiteSpace(subscriptionId)) {
+                throw new ArgumentException(Resources.Error_ParameterIsRequired, nameof(subscriptionId));
+            }
+            if (string.IsNullOrWhiteSpace(topic)) {
+                throw new ArgumentException(Resources.Error_ParameterIsRequired, nameof(topic));
+            }
+
+            var connection = await _client.GetHubConnection(true, cancellationToken).ConfigureAwait(false);
+            return await connection.StreamAsChannelAsync<EventMessage>(
+                "CreateEventMessageTopicChannel",
+                subscriptionId,
+                topic,
                 cancellationToken
             ).ConfigureAwait(false);
         }

--- a/src/DataCore.Adapter.AspNetCore.SignalR.Proxy/Events/EventMessagePushWithTopicsImpl.cs
+++ b/src/DataCore.Adapter.AspNetCore.SignalR.Proxy/Events/EventMessagePushWithTopicsImpl.cs
@@ -1,0 +1,207 @@
+﻿using System;
+using System.Collections.Concurrent;
+using System.Linq;
+using System.Threading;
+using System.Threading.Channels;
+using System.Threading.Tasks;
+
+using DataCore.Adapter.Events;
+
+using IntelligentPlant.BackgroundTasks;
+
+namespace DataCore.Adapter.AspNetCore.SignalR.Proxy.Events {
+
+    /// <summary>
+    /// Implements <see cref="IEventMessagePushWithTopics"/>.
+    /// </summary>
+    internal class EventMessagePushWithTopicsImpl : ProxyAdapterFeature, IEventMessagePushWithTopics {
+
+        /// <summary>
+        /// Creates a new <see cref="EventMessagePushWithTopicsImpl"/> object.
+        /// </summary>
+        /// <param name="proxy">
+        ///   The owning proxy.
+        /// </param>
+        public EventMessagePushWithTopicsImpl(SignalRAdapterProxy proxy) : base(proxy) { }
+
+
+        /// <inheritdoc />
+        public async Task<IEventMessageSubscriptionWithTopics> Subscribe(IAdapterCallContext context, CreateEventMessageSubscriptionRequest request) {
+            var result = new Subscription(
+                this,
+                context,
+                request
+            );
+
+            await result.Start().ConfigureAwait(false);
+            return result;
+        }
+
+
+        /// <summary>
+        /// <see cref="IEventMessageSubscriptionWithTopics"/> implementation for the 
+        /// <see cref="IEventMessagePushWithTopics"/> feature.
+        /// </summary>
+        private class Subscription : EventMessageSubscriptionWithTopicsBase {
+
+            /// <summary>
+            /// The feature instance.
+            /// </summary>
+            private readonly EventMessagePushWithTopicsImpl _feature;
+
+            /// <summary>
+            /// The subscription request.
+            /// </summary>
+            private readonly CreateEventMessageSubscriptionRequest _request;
+
+            /// <summary>
+            /// The remote subscription ID.
+            /// </summary>
+            private string _subscriptionId;
+
+            /// <summary>
+            /// Holds the lifetime cancellation token for each subscribed topic.
+            /// </summary>
+            private readonly ConcurrentDictionary<string, CancellationTokenSource> _topicSubscriptionLifetimes = new ConcurrentDictionary<string, CancellationTokenSource>();
+
+
+            /// <summary>
+            /// Creates a new <see cref="Subscription"/> object.
+            /// </summary>
+            /// <param name="feature">
+            ///   The feature instance.
+            /// </param>
+            /// <param name="context">
+            ///   The adapter call context for the subscriber.
+            /// </param>
+            /// <param name="request">
+            ///   Additional subscription request properties.
+            /// </param>
+            public Subscription(
+                EventMessagePushWithTopicsImpl feature,
+                IAdapterCallContext context,
+                CreateEventMessageSubscriptionRequest request
+            ) : base(context, feature.AdapterId, request?.SubscriptionType ?? EventMessageSubscriptionType.Active) {
+                _feature = feature;
+                _request = request ?? new CreateEventMessageSubscriptionRequest();
+            }
+
+
+            /// <inheritdoc/>
+            protected override async Task Init(CancellationToken cancellationToken) {
+                await base.Init(cancellationToken).ConfigureAwait(false);
+
+                // Create the subscription.
+                _subscriptionId = await _feature.GetClient().Events.CreateEventMessageTopicSubscriptionAsync(
+                    _feature.AdapterId,
+                    _request,
+                    cancellationToken
+                ).ConfigureAwait(false);
+            }
+
+
+            /// <inheritdoc/>
+            protected override Task OnTopicAdded(string topic) {
+                if (CancellationToken.IsCancellationRequested) {
+                    return Task.CompletedTask;
+                }
+
+                var added = false;
+                var ctSource = _topicSubscriptionLifetimes.GetOrAdd(topic, k => {
+                    added = true;
+                    return new CancellationTokenSource();
+                });
+
+                if (added) {
+                    var tcs = new TaskCompletionSource<bool>();
+                    _feature.TaskScheduler.QueueBackgroundWorkItem(ct => RunTopicSubscription(topic, tcs, ct), ctSource.Token, CancellationToken);
+                    return tcs.Task;
+                }
+
+                return Task.CompletedTask;
+            }
+
+
+            /// <inheritdoc/>
+            protected override Task OnTopicRemoved(string topic) {
+                if (CancellationToken.IsCancellationRequested) {
+                    return Task.CompletedTask;
+                }
+
+                if (_topicSubscriptionLifetimes.TryRemove(topic, out var ctSource)) {
+                    ctSource.Cancel();
+                    ctSource.Dispose();
+                }
+
+                return Task.CompletedTask;
+            }
+
+
+            /// <inheritdoc/>
+            protected override void OnCancelled() {
+                base.OnCancelled();
+
+                foreach (var item in _topicSubscriptionLifetimes.Values.ToArray()) {
+                    item.Cancel();
+                    item.Dispose();
+                }
+
+                _topicSubscriptionLifetimes.Clear();
+                if (!string.IsNullOrWhiteSpace(_subscriptionId)) {
+                    // Notify server of cancellation.
+                    _feature.TaskScheduler.QueueBackgroundWorkItem(ct => _feature.GetClient().Events.DeleteEventMessageTopicSubscriptionAsync(_subscriptionId, ct));
+                }
+            }
+
+
+            /// <summary>
+            /// Creates and processes a subscription to the specified topic.
+            /// </summary>
+            /// <param name="topic">
+            ///   The topic.
+            /// </param>
+            /// <param name="tcs">
+            ///   A <see cref="TaskCompletionSource{TResult}"/> that will be completed once the 
+            ///   tag subscription has been created.
+            /// </param>
+            /// <param name="cancellationToken">
+            ///   The cancellation token for the operation.
+            /// </param>
+            /// <returns>
+            ///   A long-running task that will run the subscription until the cancellation token 
+            ///   fires.
+            /// </returns>
+            private async Task RunTopicSubscription(string topic, TaskCompletionSource<bool> tcs, CancellationToken cancellationToken) {
+                ChannelReader<EventMessage> hubChannel;
+
+                try {
+                    hubChannel = await _feature.GetClient().Events.CreateEventMessageTopicChannelAsync(
+                        _subscriptionId,
+                        topic,
+                        cancellationToken
+                    ).ConfigureAwait(false);
+                }
+                catch (OperationCanceledException) {
+                    tcs.TrySetCanceled(cancellationToken);
+                    throw;
+                }
+                catch (Exception e) {
+                    tcs.TrySetException(e);
+                    throw;
+                }
+                finally {
+                    tcs.TrySetResult(true);
+                }
+
+                await hubChannel.ForEachAsync(async val => {
+                    if (val == null) {
+                        return;
+                    }
+                    await ValueReceived(val, cancellationToken).ConfigureAwait(false);
+                }, cancellationToken).ConfigureAwait(false);
+            }
+
+        }
+
+    }
+}

--- a/src/DataCore.Adapter.AspNetCore.SignalR/Hubs/AdapterHub.cs
+++ b/src/DataCore.Adapter.AspNetCore.SignalR/Hubs/AdapterHub.cs
@@ -232,6 +232,7 @@ namespace DataCore.Adapter.AspNetCore.Hubs {
         /// <inheritdoc/>
         public override Task OnDisconnectedAsync(Exception exception) {
             OnTagValuesHubDisconnection();
+            OnEventsHubDisconnection();
             return base.OnDisconnectedAsync(exception);
         }
 
@@ -240,6 +241,12 @@ namespace DataCore.Adapter.AspNetCore.Hubs {
         /// Invoked when a client disconnects.
         /// </summary>
         partial void OnTagValuesHubDisconnection();
+
+
+        /// <summary>
+        /// Invoked when a client disconnects.
+        /// </summary>
+        partial void OnEventsHubDisconnection();
 
     }
 }

--- a/src/DataCore.Adapter.AspNetCore.SignalR/Hubs/EventsHub.cs
+++ b/src/DataCore.Adapter.AspNetCore.SignalR/Hubs/EventsHub.cs
@@ -16,7 +16,138 @@ namespace DataCore.Adapter.AspNetCore.Hubs {
         #region [ Subscription Management ]
 
         /// <summary>
-        /// Creates a channel that will receive event messages from the specified adapter.
+        /// Holds topic-based event subscriptions for all connections.
+        /// </summary>
+        private static readonly ConnectionSubscriptionManager<EventMessage, TopicSubscriptionWrapper<EventMessage>> s_eventTopicSubscriptions = new ConnectionSubscriptionManager<EventMessage, TopicSubscriptionWrapper<EventMessage>>();
+
+
+        /// <summary>
+        /// Invoked when a client disconnects.
+        /// </summary>
+        partial void OnEventsHubDisconnection() {
+            s_eventTopicSubscriptions.RemoveAllSubscriptions(Context.ConnectionId);
+        }
+
+
+        /// <summary>
+        /// Creates a topic-based event subscription for an adapter using the adapter's 
+        /// <see cref="IEventMessagePushWithTopics"/> feature. Note that this does not add any 
+        /// event topics to the subscription; this must be done separately via calls to 
+        /// <see cref="CreateEventMessageTopicChannel"/>.
+        /// </summary>
+        /// <param name="adapterId">
+        ///   The ID of the adapter to subscribe to.
+        /// </param>
+        /// <param name="request">
+        ///   The subscription request parameters.
+        /// </param>
+        /// <returns>
+        ///   A <see cref="Task{TResult}"/> that will return the ID for the subscription.
+        /// </returns>
+        public async Task<string> CreateEventMessageTopicSubscription(string adapterId, CreateEventMessageSubscriptionRequest request) {
+            // Resolve the adapter and feature.
+            var adapterCallContext = new SignalRAdapterCallContext(Context);
+            var adapter = await ResolveAdapterAndFeature<IEventMessagePushWithTopics>(adapterCallContext, adapterId, Context.ConnectionAborted).ConfigureAwait(false);
+
+#pragma warning disable CA2000 // Dispose objects before losing scope
+            var wrappedSubscription = new TopicSubscriptionWrapper<EventMessage>(
+                await adapter.Feature.Subscribe(adapterCallContext, request).ConfigureAwait(false),
+                TaskScheduler
+            );
+#pragma warning restore CA2000 // Dispose objects before losing scope
+            return s_eventTopicSubscriptions.AddSubscription(Context.ConnectionId, wrappedSubscription);
+        }
+
+
+        /// <summary>
+        /// Deletes a topic-based event subscription that wa created using <see cref="CreateEventMessageTopicSubscription"/>. 
+        /// This will cancel all active calls to <see cref="CreateEventMessageTopicChannel"/> 
+        /// for the subscription.
+        /// </summary>
+        /// <param name="subscriptionId">
+        ///   The subscription ID. Specify <see langword="null"/> to delete all subscriptions for 
+        ///   the connection. Subscriptions are created via calls to <see cref="CreateEventMessageTopicSubscription"/>.
+        /// </param>
+        /// <returns>
+        ///   A <see cref="Task{TResult}"/> that will return a flag indicating if the operation 
+        ///   was successful.
+        /// </returns>
+        public Task<bool> DeleteEventMessageTopicSubscription(
+            string subscriptionId
+        ) {
+            if (string.IsNullOrWhiteSpace(subscriptionId)) {
+                s_snapshotSubscriptions.RemoveAllSubscriptions(Context.ConnectionId);
+                return Task.FromResult(true);
+            }
+            var result = s_eventTopicSubscriptions.RemoveSubscription(Context.ConnectionId, subscriptionId);
+            return Task.FromResult(result);
+        }
+
+
+        /// <summary>
+        /// Subscribes to receive event messages for the specified event topic.
+        /// </summary>
+        /// <param name="subscriptionId">
+        ///   The subscription ID to add the event topic to. Subscriptions are created via calls to 
+        ///   <see cref="CreateEventMessageTopicSubscription"/>.
+        /// </param>
+        /// <param name="topicName">
+        ///   The topic name to subscribe to.
+        /// </param>
+        /// <param name="cancellationToken">
+        ///   The cancellation token for the operation.
+        /// </param>
+        /// <returns>
+        ///   A <see cref="Task{TResult}"/> that will return a channel that emits event messages 
+        ///   for the topic.
+        /// </returns>
+        public Task<ChannelReader<EventMessage>> CreateEventMessageTopicChannel(
+            string subscriptionId,
+            string topicName,
+            CancellationToken cancellationToken
+        ) {
+            if (string.IsNullOrWhiteSpace(subscriptionId)) {
+                throw new ArgumentException(Resources.Error_SubscriptionIdRequired, nameof(subscriptionId));
+            }
+            if (string.IsNullOrWhiteSpace(topicName)) {
+                throw new ArgumentException(Resources.Error_EventTopicNameRequired, nameof(topicName));
+            }
+
+            if (!s_eventTopicSubscriptions.TryGetSubscription(Context.ConnectionId, subscriptionId, out var subscription)) {
+                throw new ArgumentException(Resources.Error_SubscriptionDoesNotExist, nameof(subscriptionId));
+            }
+
+            var result = Channel.CreateUnbounded<EventMessage>();
+
+            result.Writer.RunBackgroundOperation(async (ch, ct) => {
+                var topicChannel = await subscription.CreateTopicChannel(topicName).ConfigureAwait(false);
+                try {
+                    while (!ct.IsCancellationRequested) {
+                        try {
+                            var val = await topicChannel.Reader.ReadAsync(ct).ConfigureAwait(false);
+                            await ch.WriteAsync(val, ct).ConfigureAwait(false);
+                        }
+                        catch (OperationCanceledException) { }
+                        catch (ChannelClosedException) { }
+                    }
+                }
+#pragma warning disable CA1031 // Do not catch general exception types
+                catch (Exception e) {
+#pragma warning restore CA1031 // Do not catch general exception types
+                    topicChannel.Writer.TryComplete(e);
+                }
+                finally {
+                    await topicChannel.DisposeAsync().ConfigureAwait(false);
+                }
+            }, true, TaskScheduler, cancellationToken);
+
+            return Task.FromResult(result.Reader);
+        }
+
+
+        /// <summary>
+        /// Creates a channel that will receive event messages from the specified adapter using 
+        /// the <see cref="IEventMessagePush"/> feature.
         /// </summary>
         /// <param name="adapterId">
         ///   The adapter ID.

--- a/src/DataCore.Adapter.AspNetCore.SignalR/Hubs/TagValuesHub.cs
+++ b/src/DataCore.Adapter.AspNetCore.SignalR/Hubs/TagValuesHub.cs
@@ -149,7 +149,7 @@ namespace DataCore.Adapter.AspNetCore.Hubs {
 
         /// <summary>
         /// Gets snapshot tag values via polling. Use <see cref="CreateSnapshotTagValueSubscription"/> 
-        /// and <see cref="CreateSnapshotTagValueSubscriptionChannel"/> to receive snapshot tag 
+        /// and <see cref="CreateSnapshotTagValueChannel"/> to receive snapshot tag 
         /// values via push messages.
         /// </summary>
         /// <param name="adapterId">

--- a/src/DataCore.Adapter.AspNetCore.SignalR/Resources.Designer.cs
+++ b/src/DataCore.Adapter.AspNetCore.SignalR/Resources.Designer.cs
@@ -97,6 +97,15 @@ namespace DataCore.Adapter.AspNetCore {
         }
         
         /// <summary>
+        ///   Looks up a localized string similar to An event topic name is required..
+        /// </summary>
+        internal static string Error_EventTopicNameRequired {
+            get {
+                return ResourceManager.GetString("Error_EventTopicNameRequired", resourceCulture);
+            }
+        }
+        
+        /// <summary>
         ///   Looks up a localized string similar to You are not authorized to access this feature..
         /// </summary>
         internal static string Error_NotAuthorizedToAccessFeature {

--- a/src/DataCore.Adapter.AspNetCore.SignalR/Resources.resx
+++ b/src/DataCore.Adapter.AspNetCore.SignalR/Resources.resx
@@ -133,6 +133,9 @@
     <value>Unable to resolve adapter ID: {0}</value>
     <comment>{0} - adapter ID</comment>
   </data>
+  <data name="Error_EventTopicNameRequired" xml:space="preserve">
+    <value>An event topic name is required.</value>
+  </data>
   <data name="Error_NotAuthorizedToAccessFeature" xml:space="preserve">
     <value>You are not authorized to access this feature.</value>
   </data>

--- a/src/DataCore.Adapter.Core/Events/EventMessage.cs
+++ b/src/DataCore.Adapter.Core/Events/EventMessage.cs
@@ -17,6 +17,9 @@ namespace DataCore.Adapter.Events {
         ///   The unique identifier for the event message. If <see langword="null"/>, an 
         ///   identifier will be generated.
         /// </param>
+        /// <param name="topic">
+        ///   The event message topic e.g. the MQTT channel that emitted the message.
+        /// </param>
         /// <param name="utcEventTime">
         ///   The UTC timestamp of the event.
         /// </param>
@@ -34,12 +37,13 @@ namespace DataCore.Adapter.Events {
         /// </param>
         public EventMessage(
             string id, 
+            string topic,
             DateTime utcEventTime, 
             EventPriority priority, 
             string category, 
             string message, 
             IEnumerable<AdapterProperty> properties
-        ) : base(id ?? Guid.NewGuid().ToString(), utcEventTime, priority, category, message, properties) { }
+        ) : base(id ?? Guid.NewGuid().ToString(), topic, utcEventTime, priority, category, message, properties) { }
 
 
         /// <summary>
@@ -48,6 +52,9 @@ namespace DataCore.Adapter.Events {
         /// <param name="id">
         ///   The unique identifier for the event message. If <see langword="null"/>, an 
         ///   identifier will be generated.
+        /// </param>
+        /// <param name="topic">
+        ///   The event message topic e.g. the MQTT channel that emitted the message.
         /// </param>
         /// <param name="utcEventTime">
         ///   The UTC timestamp of the event.
@@ -64,8 +71,8 @@ namespace DataCore.Adapter.Events {
         /// <param name="properties">
         ///   Additional event properties.
         /// </param>
-        public static EventMessage Create(string id, DateTime utcEventTime, EventPriority priority, string category, string message, IEnumerable<AdapterProperty> properties) {
-            return new EventMessage(id, utcEventTime, priority, category, message, properties);
+        public static EventMessage Create(string id, string topic, DateTime utcEventTime, EventPriority priority, string category, string message, IEnumerable<AdapterProperty> properties) {
+            return new EventMessage(id, topic, utcEventTime, priority, category, message, properties);
         }
     
     }

--- a/src/DataCore.Adapter.Core/Events/EventMessageBase.cs
+++ b/src/DataCore.Adapter.Core/Events/EventMessageBase.cs
@@ -18,6 +18,16 @@ namespace DataCore.Adapter.Events {
         public string Id { get; }
 
         /// <summary>
+        /// The topic for the event (when the event is emitted by an adapter that supports 
+        /// topic-based event messages).
+        /// </summary>
+        /// <remarks>
+        ///   The topic might be set using e.g. the MQTT channel or the OPC UA node that emitted 
+        ///   the message
+        /// </remarks>
+        public string Topic { get; }
+
+        /// <summary>
         /// The UTC timestamp of the event.
         /// </summary>
         public DateTime UtcEventTime { get; }
@@ -49,6 +59,9 @@ namespace DataCore.Adapter.Events {
         /// <param name="id">
         ///   The event message ID.
         /// </param>
+        /// <param name="topic">
+        ///   The event message topic e.g. the MQTT channel that emitted the message.
+        /// </param>
         /// <param name="utcEventTime">
         ///   The UTC event time.
         /// </param>
@@ -64,8 +77,9 @@ namespace DataCore.Adapter.Events {
         /// <param name="properties">
         ///   The event properties.
         /// </param>
-        protected EventMessageBase(string id, DateTime utcEventTime, EventPriority priority, string category, string message, IEnumerable<AdapterProperty> properties) {
+        protected EventMessageBase(string id, string topic, DateTime utcEventTime, EventPriority priority, string category, string message, IEnumerable<AdapterProperty> properties) {
             Id = id ?? throw new ArgumentNullException(nameof(id));
+            Topic = topic;
             UtcEventTime = utcEventTime;
             Priority = priority;
             Category = category;

--- a/src/DataCore.Adapter.Core/Events/EventMessageWithCursorPosition.cs
+++ b/src/DataCore.Adapter.Core/Events/EventMessageWithCursorPosition.cs
@@ -25,6 +25,9 @@ namespace DataCore.Adapter.Events {
         ///   The unique identifier for the event message. If <see langword="null"/>, an 
         ///   identifier will be generated.
         /// </param>
+        /// <param name="topic">
+        ///   The event message topic e.g. the MQTT channel that emitted the message.
+        /// </param>
         /// <param name="utcEventTime">
         ///   The UTC timestamp of the event.
         /// </param>
@@ -48,13 +51,14 @@ namespace DataCore.Adapter.Events {
         /// </exception>
         public EventMessageWithCursorPosition(
             string id, 
+            string topic,
             DateTime utcEventTime, 
             EventPriority priority, 
             string category, 
             string message, 
             IEnumerable<AdapterProperty> properties, 
             string cursorPosition
-        ) : base(id, utcEventTime, priority, category, message, properties) {
+        ) : base(id, topic, utcEventTime, priority, category, message, properties) {
             CursorPosition = cursorPosition ?? throw new ArgumentNullException(nameof(cursorPosition));
         }
 
@@ -64,6 +68,9 @@ namespace DataCore.Adapter.Events {
         /// </summary>
         /// <param name="id">
         ///   The unique identifier for the event message.
+        /// </param>
+        /// <param name="topic">
+        ///   The event message topic e.g. the MQTT channel that emitted the message.
         /// </param>
         /// <param name="utcEventTime">
         ///   The UTC timestamp of the event.
@@ -86,8 +93,8 @@ namespace DataCore.Adapter.Events {
         /// <exception cref="ArgumentNullException">
         ///   <paramref name="cursorPosition"/> is <see langword="null"/>.
         /// </exception>
-        public static EventMessageWithCursorPosition Create(string id, DateTime utcEventTime, EventPriority priority, string category, string message, IEnumerable<AdapterProperty> properties, string cursorPosition) {
-            return new EventMessageWithCursorPosition(id, utcEventTime, priority, category, message, properties, cursorPosition);
+        public static EventMessageWithCursorPosition Create(string id, string topic, DateTime utcEventTime, EventPriority priority, string category, string message, IEnumerable<AdapterProperty> properties, string cursorPosition) {
+            return new EventMessageWithCursorPosition(id, topic, utcEventTime, priority, category, message, properties, cursorPosition);
         }
 
     }

--- a/src/DataCore.Adapter.Core/Events/ReadHistoricalEventMessagesRequest.cs
+++ b/src/DataCore.Adapter.Core/Events/ReadHistoricalEventMessagesRequest.cs
@@ -1,6 +1,4 @@
-﻿using System.ComponentModel;
-using System.ComponentModel.DataAnnotations;
-using DataCore.Adapter.Common;
+﻿using DataCore.Adapter.Common;
 
 namespace DataCore.Adapter.Events {
 
@@ -8,6 +6,12 @@ namespace DataCore.Adapter.Events {
     /// Base class for adapter requests related to reading historical event messages.
     /// </summary>
     public abstract class ReadHistoricalEventMessagesRequest : AdapterRequest {
+
+        /// <summary>
+        /// The topics to read messages for. This property will be ignored if the adapter does not 
+        /// support a topic-based event model.
+        /// </summary>
+        public string[] Topics { get; set; }
 
         /// <summary>
         /// The event read direction. When <see cref="EventReadDirection.Backwards"/> is specified, 

--- a/src/DataCore.Adapter.Core/RealTimeData/CreateAnnotationRequest.cs
+++ b/src/DataCore.Adapter.Core/RealTimeData/CreateAnnotationRequest.cs
@@ -1,11 +1,13 @@
 ﻿using System.ComponentModel.DataAnnotations;
 
+using DataCore.Adapter.Common;
+
 namespace DataCore.Adapter.RealTimeData {
 
     /// <summary>
     /// Describes a request to create a new tag value annotation.
     /// </summary>
-    public class CreateAnnotationRequest {
+    public class CreateAnnotationRequest : AdapterRequest {
 
         /// <summary>
         /// The ID or name of the tag that the annotation is associated with.

--- a/src/DataCore.Adapter.Core/RealTimeData/DeleteAnnotationRequest.cs
+++ b/src/DataCore.Adapter.Core/RealTimeData/DeleteAnnotationRequest.cs
@@ -1,11 +1,13 @@
 ﻿using System.ComponentModel.DataAnnotations;
 
+using DataCore.Adapter.Common;
+
 namespace DataCore.Adapter.RealTimeData {
 
     /// <summary>
     /// Describes a request to delete a tag value annotation.
     /// </summary>
-    public class DeleteAnnotationRequest {
+    public class DeleteAnnotationRequest : AdapterRequest {
 
         /// <summary>
         /// The tag ID or name.

--- a/src/DataCore.Adapter.Core/RealTimeData/UpdateAnnotationRequest.cs
+++ b/src/DataCore.Adapter.Core/RealTimeData/UpdateAnnotationRequest.cs
@@ -1,11 +1,13 @@
 ﻿using System.ComponentModel.DataAnnotations;
 
+using DataCore.Adapter.Common;
+
 namespace DataCore.Adapter.RealTimeData {
 
     /// <summary>
     /// Describes a request to update an existing tag value annotation.
     /// </summary>
-    public class UpdateAnnotationRequest {
+    public class UpdateAnnotationRequest : AdapterRequest {
 
         /// <summary>
         /// The tag name or ID.

--- a/src/DataCore.Adapter.Grpc.Proxy/AssetModel/AssetModelBrowseImpl.cs
+++ b/src/DataCore.Adapter.Grpc.Proxy/AssetModel/AssetModelBrowseImpl.cs
@@ -29,6 +29,11 @@ namespace DataCore.Adapter.Grpc.Proxy.AssetModel.Features {
                 PageSize = request.PageSize,
                 Page = request.Page
             };
+            if (request.Properties != null) {
+                foreach (var prop in request.Properties) {
+                    grpcRequest.Properties.Add(prop.Key, prop.Value ?? string.Empty);
+                }
+            }
             var grpcResponse = client.BrowseAssetModelNodes(grpcRequest, GetCallOptions(context, cancellationToken));
 
             var result = ChannelExtensions.CreateAssetModelNodeChannel(-1);
@@ -58,6 +63,11 @@ namespace DataCore.Adapter.Grpc.Proxy.AssetModel.Features {
                 AdapterId = AdapterId
             };
             grpcRequest.Nodes.AddRange(request.Nodes);
+            if (request.Properties != null) {
+                foreach (var prop in request.Properties) {
+                    grpcRequest.Properties.Add(prop.Key, prop.Value ?? string.Empty);
+                }
+            }
             var grpcResponse = client.GetAssetModelNodes(grpcRequest, GetCallOptions(context, cancellationToken));
 
             var result = ChannelExtensions.CreateAssetModelNodeChannel(-1);

--- a/src/DataCore.Adapter.Grpc.Proxy/AssetModel/AssetModelSearchImpl.cs
+++ b/src/DataCore.Adapter.Grpc.Proxy/AssetModel/AssetModelSearchImpl.cs
@@ -30,6 +30,11 @@ namespace DataCore.Adapter.Grpc.Proxy.AssetModel.Features {
                 PageSize = request.PageSize,
                 Page = request.Page
             };
+            if (request.Properties != null) {
+                foreach (var prop in request.Properties) {
+                    grpcRequest.Properties.Add(prop.Key, prop.Value ?? string.Empty);
+                }
+            }
             var grpcResponse = client.FindAssetModelNodes(grpcRequest, GetCallOptions(context, cancellationToken));
 
             var result = ChannelExtensions.CreateAssetModelNodeChannel(-1);

--- a/src/DataCore.Adapter.Grpc.Proxy/Events/EventMessagePushWithTopicsImpl.cs
+++ b/src/DataCore.Adapter.Grpc.Proxy/Events/EventMessagePushWithTopicsImpl.cs
@@ -1,0 +1,259 @@
+﻿using System;
+using System.Collections.Concurrent;
+using System.Collections.Generic;
+using System.Linq;
+using System.Text;
+using System.Threading;
+using System.Threading.Tasks;
+
+using DataCore.Adapter.Events;
+
+using IntelligentPlant.BackgroundTasks;
+
+using GrpcCore = Grpc.Core;
+
+namespace DataCore.Adapter.Grpc.Proxy.Events {
+
+    /// <summary>
+    /// <see cref="IEventMessageSubscriptionWithTopics"/> implementation.
+    /// </summary>
+    internal class EventMessagePushWithTopicsImpl : ProxyAdapterFeature, IEventMessagePushWithTopics {
+
+        /// <summary>
+        /// Creates a new <see cref="EventMessagePushWithTopicsImpl"/> instance.
+        /// </summary>
+        /// <param name="proxy">
+        ///   The proxy that owns the instance.
+        /// </param>
+        public EventMessagePushWithTopicsImpl(GrpcAdapterProxy proxy) : base(proxy) { }
+
+
+        /// <inheritdoc/>
+        public async Task<IEventMessageSubscriptionWithTopics> Subscribe(IAdapterCallContext context, CreateEventMessageSubscriptionRequest request) {
+            var result = new Subscription(
+                this,
+                context,
+                request
+            );
+            await result.Start().ConfigureAwait(false);
+            return result;
+        }
+
+
+        /// <inheritdoc />
+        public async ValueTask DisposeAsync() {
+            try {
+                // Ensure that we delete all subscriptions for this connection.
+                var request = new DeleteEventTopicPushSubscriptionRequest() {
+                    SessionId = RemoteSessionId,
+                    SubscriptionId = string.Empty
+                };
+                var response = CreateClient<EventsService.EventsServiceClient>().DeleteEventTopicPushSubscriptionAsync(request, GetCallOptions(null, default));
+                await response.ResponseAsync.ConfigureAwait(false);
+            }
+#pragma warning disable CA1031 // Do not catch general exception types
+            catch { }
+#pragma warning restore CA1031 // Do not catch general exception types
+        }
+
+
+        /// <summary>
+        /// <see cref="IEventMessageSubscriptionWithTopics"/> implementation for the 
+        /// <see cref="IEventMessagePushWithTopics"/> feature.
+        /// </summary>
+        private class Subscription : EventMessageSubscriptionWithTopicsBase {
+
+            /// <summary>
+            /// The feature instance.
+            /// </summary>
+            private readonly EventMessagePushWithTopicsImpl _feature;
+
+            /// <summary>
+            /// The subscription request.
+            /// </summary>
+            private readonly CreateEventMessageSubscriptionRequest _request;
+
+            /// <summary>
+            /// The remote subscription ID.
+            /// </summary>
+            private string _subscriptionId;
+
+            /// <summary>
+            /// The client for the gRPC service.
+            /// </summary>
+            private readonly EventsService.EventsServiceClient _client;
+
+            /// <summary>
+            /// Holds the lifetime cancellation token for each subscribed topic.
+            /// </summary>
+            private readonly ConcurrentDictionary<string, CancellationTokenSource> _topicSubscriptionLifetimes = new ConcurrentDictionary<string, CancellationTokenSource>();
+
+
+            /// <summary>
+            /// Creates a new <see cref="Subscription"/> object.
+            /// </summary>
+            /// <param name="feature">
+            ///   The feature instance.
+            /// </param>
+            /// <param name="context">
+            ///   The adapter call context for the subscriber.
+            /// </param>
+            /// <param name="request">
+            ///   Additional subscription request properties.
+            /// </param>
+            public Subscription(
+                EventMessagePushWithTopicsImpl feature,
+                IAdapterCallContext context,
+                CreateEventMessageSubscriptionRequest request
+            ) : base(context, feature.AdapterId, request?.SubscriptionType ?? EventMessageSubscriptionType.Active) {
+                _feature = feature;
+                _request = request ?? new CreateEventMessageSubscriptionRequest();
+                _client = _feature.CreateClient<EventsService.EventsServiceClient>();
+            }
+
+
+            /// <inheritdoc/>
+            protected override async Task Init(CancellationToken cancellationToken) {
+                await base.Init(cancellationToken).ConfigureAwait(false);
+
+                // Create the subscription.
+                var request = new CreateEventTopicPushSubscriptionRequest() {
+                    SessionId = _feature.RemoteSessionId,
+                    AdapterId = _feature.AdapterId
+                };
+                if (_request.Properties != null) {
+                    foreach (var item in _request.Properties) {
+                        request.Properties.Add(item.Key, item.Value ?? string.Empty);
+                    }
+                }
+
+                var response = _client.CreateEventTopicPushSubscriptionAsync(
+                    request,
+                    _feature.GetCallOptions(Context, cancellationToken)
+                );
+
+                var result = await response.ResponseAsync.ConfigureAwait(false);
+                _subscriptionId = result.SubscriptionId;
+            }
+
+
+            /// <inheritdoc/>
+            protected override Task OnTopicAdded(string topic) {
+                if (CancellationToken.IsCancellationRequested) {
+                    return Task.CompletedTask;
+                }
+
+                var added = false;
+                var ctSource = _topicSubscriptionLifetimes.GetOrAdd(topic, k => {
+                    added = true;
+                    return new CancellationTokenSource();
+                });
+
+                if (added) {
+                    var tcs = new TaskCompletionSource<bool>();
+                    _feature.TaskScheduler.QueueBackgroundWorkItem(ct => RunTopicSubscription(topic, tcs, ct), ctSource.Token, CancellationToken);
+                    return tcs.Task;
+                }
+
+                return Task.CompletedTask;
+            }
+
+
+            /// <inheritdoc/>
+            protected override Task OnTopicRemoved(string topic) {
+                if (CancellationToken.IsCancellationRequested) {
+                    return Task.CompletedTask;
+                }
+
+                if (_topicSubscriptionLifetimes.TryRemove(topic, out var ctSource)) {
+                    ctSource.Cancel();
+                    ctSource.Dispose();
+                }
+
+                return Task.CompletedTask;
+            }
+
+
+            /// <inheritdoc/>
+            protected override void OnCancelled() {
+                base.OnCancelled();
+
+                foreach (var item in _topicSubscriptionLifetimes.Values.ToArray()) {
+                    item.Cancel();
+                    item.Dispose();
+                }
+
+                _topicSubscriptionLifetimes.Clear();
+                if (!string.IsNullOrWhiteSpace(_subscriptionId)) {
+                    // Notify server of cancellation.
+                    _feature.TaskScheduler.QueueBackgroundWorkItem(async ct => {
+                        var response = _client.DeleteEventTopicPushSubscriptionAsync(new DeleteEventTopicPushSubscriptionRequest() {
+                            SubscriptionId = _subscriptionId
+                        }, _feature.GetCallOptions(Context, ct));
+
+                        await response.ResponseAsync.ConfigureAwait(false);
+                    });
+                }
+            }
+
+
+            /// <summary>
+            /// Creates and processes a subscription to the specified topic.
+            /// </summary>
+            /// <param name="topic">
+            ///   The topic.
+            /// </param>
+            /// <param name="tcs">
+            ///   A <see cref="TaskCompletionSource{TResult}"/> that will be completed once the 
+            ///   tag subscription has been created.
+            /// </param>
+            /// <param name="cancellationToken">
+            ///   The cancellation token for the operation.
+            /// </param>
+            /// <returns>
+            ///   A long-running task that will run the subscription until the cancellation token 
+            ///   fires.
+            /// </returns>
+            private async Task RunTopicSubscription(string topic, TaskCompletionSource<bool> tcs, CancellationToken cancellationToken) {
+                if (string.IsNullOrWhiteSpace(_subscriptionId)) {
+                    tcs.TrySetResult(false);
+                    return;
+                }
+
+                GrpcCore.AsyncServerStreamingCall<EventMessage> grpcChannel;
+
+                try {
+                    grpcChannel = _client.CreateEventTopicPushChannel(new CreateEventTopicPushChannelRequest() {
+                        SessionId = _feature.RemoteSessionId,
+                        SubscriptionId = _subscriptionId,
+                        Topic = topic
+                    }, _feature.GetCallOptions(Context, cancellationToken));
+                }
+                catch (OperationCanceledException) {
+                    tcs.TrySetCanceled(cancellationToken);
+                    throw;
+                }
+                catch (Exception e) {
+                    tcs.TrySetException(e);
+                    throw;
+                }
+                finally {
+                    tcs.TrySetResult(true);
+                }
+
+                while (await grpcChannel.ResponseStream.MoveNext(cancellationToken).ConfigureAwait(false)) {
+                    if (grpcChannel.ResponseStream.Current == null) {
+                        continue;
+                    }
+
+                    await ValueReceived(
+                        grpcChannel.ResponseStream.Current.ToAdapterEventMessage(),
+                        cancellationToken
+                    ).ConfigureAwait(false);
+                }
+            }
+
+        }
+
+    }
+}

--- a/src/DataCore.Adapter.Grpc.Proxy/Events/ReadEventMessagesForTimeRangeImpl.cs
+++ b/src/DataCore.Adapter.Grpc.Proxy/Events/ReadEventMessagesForTimeRangeImpl.cs
@@ -31,6 +31,16 @@ namespace DataCore.Adapter.Grpc.Proxy.Events.Features {
                 PageSize = request.PageSize,
                 Page = request.Page
             };
+            if (request.Topics != null) {
+                foreach (var item in request.Topics) {
+                    grpcRequest.Topics.Add(item ?? string.Empty);
+                }
+            }
+            if (request.Properties != null) {
+                foreach (var prop in request.Properties) {
+                    grpcRequest.Properties.Add(prop.Key, prop.Value ?? string.Empty);
+                }
+            }
             var grpcResponse = client.GetEventMessagesForTimeRange(grpcRequest, GetCallOptions(context, cancellationToken));
 
             var result = ChannelExtensions.CreateEventMessageChannel<Adapter.Events.EventMessage>(-1);

--- a/src/DataCore.Adapter.Grpc.Proxy/Events/ReadEventMessagesUsingCursorImpl.cs
+++ b/src/DataCore.Adapter.Grpc.Proxy/Events/ReadEventMessagesUsingCursorImpl.cs
@@ -29,6 +29,16 @@ namespace DataCore.Adapter.Grpc.Proxy.Events.Features {
                 Direction = request.Direction.ToGrpcEventReadDirection(),
                 PageSize = request.PageSize
             };
+            if (request.Topics != null) {
+                foreach (var item in request.Topics) {
+                    grpcRequest.Topics.Add(item ?? string.Empty);
+                }
+            }
+            if (request.Properties != null) {
+                foreach (var prop in request.Properties) {
+                    grpcRequest.Properties.Add(prop.Key, prop.Value ?? string.Empty);
+                }
+            }
             var grpcResponse = client.GetEventMessagesUsingCursorPosition(grpcRequest, GetCallOptions(context, cancellationToken));
 
             var result = ChannelExtensions.CreateEventMessageChannel<Adapter.Events.EventMessageWithCursorPosition>(-1);

--- a/src/DataCore.Adapter.Grpc.Proxy/RealTimeData/ReadPlotTagValuesImpl.cs
+++ b/src/DataCore.Adapter.Grpc.Proxy/RealTimeData/ReadPlotTagValuesImpl.cs
@@ -30,6 +30,11 @@ namespace DataCore.Adapter.Grpc.Proxy.RealTimeData.Features {
                 Intervals = request.Intervals
             };
             grpcRequest.Tags.AddRange(request.Tags);
+            if (request.Properties != null) {
+                foreach (var prop in request.Properties) {
+                    grpcRequest.Properties.Add(prop.Key, prop.Value ?? string.Empty);
+                }
+            }
 
             var grpcResponse = client.ReadPlotTagValues(grpcRequest, GetCallOptions(context, cancellationToken));
 

--- a/src/DataCore.Adapter.Grpc.Proxy/RealTimeData/ReadProcessedTagValuesImpl.cs
+++ b/src/DataCore.Adapter.Grpc.Proxy/RealTimeData/ReadProcessedTagValuesImpl.cs
@@ -60,6 +60,11 @@ namespace DataCore.Adapter.Grpc.Proxy.RealTimeData.Features {
             };
             grpcRequest.Tags.AddRange(request.Tags);
             grpcRequest.DataFunctions.AddRange(request.DataFunctions);
+            if (request.Properties != null) {
+                foreach (var prop in request.Properties) {
+                    grpcRequest.Properties.Add(prop.Key, prop.Value ?? string.Empty);
+                }
+            }
 
             var grpcResponse = client.ReadProcessedTagValues(grpcRequest, GetCallOptions(context, cancellationToken));
 

--- a/src/DataCore.Adapter.Grpc.Proxy/RealTimeData/ReadRawTagValuesImpl.cs
+++ b/src/DataCore.Adapter.Grpc.Proxy/RealTimeData/ReadRawTagValuesImpl.cs
@@ -31,6 +31,11 @@ namespace DataCore.Adapter.Grpc.Proxy.RealTimeData.Features {
                 BoundaryType = request.BoundaryType.ToGrpcRawDataBoundaryType()
             };
             grpcRequest.Tags.AddRange(request.Tags);
+            if (request.Properties != null) {
+                foreach (var prop in request.Properties) {
+                    grpcRequest.Properties.Add(prop.Key, prop.Value ?? string.Empty);
+                }
+            }
 
             var grpcResponse = client.ReadRawTagValues(grpcRequest, GetCallOptions(context, cancellationToken));
 

--- a/src/DataCore.Adapter.Grpc.Proxy/RealTimeData/ReadSnapshotTagValuesImpl.cs
+++ b/src/DataCore.Adapter.Grpc.Proxy/RealTimeData/ReadSnapshotTagValuesImpl.cs
@@ -27,6 +27,11 @@ namespace DataCore.Adapter.Grpc.Proxy.RealTimeData.Features {
                 AdapterId = AdapterId
             };
             grpcRequest.Tags.AddRange(request.Tags);
+            if (request.Properties != null) {
+                foreach (var prop in request.Properties) {
+                    grpcRequest.Properties.Add(prop.Key, prop.Value ?? string.Empty);
+                }
+            }
 
             var grpcResponse = client.ReadSnapshotTagValues(grpcRequest, GetCallOptions(context, cancellationToken));
 

--- a/src/DataCore.Adapter.Grpc.Proxy/RealTimeData/ReadTagValueAnnotationsImpl.cs
+++ b/src/DataCore.Adapter.Grpc.Proxy/RealTimeData/ReadTagValueAnnotationsImpl.cs
@@ -25,7 +25,8 @@ namespace DataCore.Adapter.Grpc.Proxy.RealTimeData.Features {
             var grpcRequest = new ReadAnnotationsRequest() {
                 AdapterId = AdapterId,
                 UtcStartTime = Google.Protobuf.WellKnownTypes.Timestamp.FromDateTime(request.UtcStartTime),
-                UtcEndTime = Google.Protobuf.WellKnownTypes.Timestamp.FromDateTime(request.UtcEndTime)
+                UtcEndTime = Google.Protobuf.WellKnownTypes.Timestamp.FromDateTime(request.UtcEndTime),
+                MaxAnnotationCount = request.AnnotationCount
             };
             grpcRequest.Tags.AddRange(request.Tags);
             if (request.Properties != null) {

--- a/src/DataCore.Adapter.Grpc.Proxy/RealTimeData/ReadTagValueAnnotationsImpl.cs
+++ b/src/DataCore.Adapter.Grpc.Proxy/RealTimeData/ReadTagValueAnnotationsImpl.cs
@@ -28,6 +28,11 @@ namespace DataCore.Adapter.Grpc.Proxy.RealTimeData.Features {
                 UtcEndTime = Google.Protobuf.WellKnownTypes.Timestamp.FromDateTime(request.UtcEndTime)
             };
             grpcRequest.Tags.AddRange(request.Tags);
+            if (request.Properties != null) {
+                foreach (var prop in request.Properties) {
+                    grpcRequest.Properties.Add(prop.Key, prop.Value ?? string.Empty);
+                }
+            }
 
             var grpcResponse = client.ReadAnnotations(grpcRequest, GetCallOptions(context, cancellationToken));
 

--- a/src/DataCore.Adapter.Grpc.Proxy/RealTimeData/ReadTagValuesAtTimesImpl.cs
+++ b/src/DataCore.Adapter.Grpc.Proxy/RealTimeData/ReadTagValuesAtTimesImpl.cs
@@ -29,6 +29,11 @@ namespace DataCore.Adapter.Grpc.Proxy.RealTimeData.Features {
             };
             grpcRequest.Tags.AddRange(request.Tags);
             grpcRequest.UtcSampleTimes.AddRange(request.UtcSampleTimes.Select(x => Google.Protobuf.WellKnownTypes.Timestamp.FromDateTime(x)));
+            if (request.Properties != null) {
+                foreach (var prop in request.Properties) {
+                    grpcRequest.Properties.Add(prop.Key, prop.Value ?? string.Empty);
+                }
+            }
 
             var grpcResponse = client.ReadTagValuesAtTimes(grpcRequest, GetCallOptions(context, cancellationToken));
 

--- a/src/DataCore.Adapter.Grpc.Proxy/RealTimeData/TagSearchImpl.cs
+++ b/src/DataCore.Adapter.Grpc.Proxy/RealTimeData/TagSearchImpl.cs
@@ -37,6 +37,11 @@ namespace DataCore.Adapter.Grpc.Proxy.RealTimeData.Features {
                     grpcRequest.Other[item.Key] = item.Value;
                 }
             }
+            if (request.Properties != null) {
+                foreach (var prop in request.Properties) {
+                    grpcRequest.Properties.Add(prop.Key, prop.Value ?? string.Empty);
+                }
+            }
 
             var grpcResponse = client.FindTags(grpcRequest, GetCallOptions(context, cancellationToken));
 

--- a/src/DataCore.Adapter.Grpc.Proxy/RealTimeData/WriteTagValueAnnotationsImpl.cs
+++ b/src/DataCore.Adapter.Grpc.Proxy/RealTimeData/WriteTagValueAnnotationsImpl.cs
@@ -26,6 +26,13 @@ namespace DataCore.Adapter.Grpc.Proxy.RealTimeData.Features {
                 Tag = request.Tag ?? string.Empty,
                 Annotation = request.Annotation.ToGrpcTagValueAnnotationBase()
             };
+
+            if (request.Properties != null) {
+                foreach (var prop in request.Properties) {
+                    grpcRequest.Properties.Add(prop.Key, prop.Value ?? string.Empty);
+                }
+            }
+
             var grpcResponse = client.CreateAnnotationAsync(grpcRequest, GetCallOptions(context, cancellationToken));
             var result = await grpcResponse.ResponseAsync.ConfigureAwait(false);
 
@@ -42,6 +49,13 @@ namespace DataCore.Adapter.Grpc.Proxy.RealTimeData.Features {
                 AnnotationId = request.AnnotationId ?? string.Empty,
                 Annotation = request.Annotation.ToGrpcTagValueAnnotationBase()
             };
+
+            if (request.Properties != null) {
+                foreach (var prop in request.Properties) {
+                    grpcRequest.Properties.Add(prop.Key, prop.Value ?? string.Empty);
+                }
+            }
+
             var grpcResponse = client.UpdateAnnotationAsync(grpcRequest, GetCallOptions(context, cancellationToken));
             var result = await grpcResponse.ResponseAsync.ConfigureAwait(false);
 
@@ -57,6 +71,13 @@ namespace DataCore.Adapter.Grpc.Proxy.RealTimeData.Features {
                 Tag = request.Tag ?? string.Empty,
                 AnnotationId = request.AnnotationId ?? string.Empty
             };
+
+            if (request.Properties != null) {
+                foreach (var prop in request.Properties) {
+                    grpcRequest.Properties.Add(prop.Key, prop.Value ?? string.Empty);
+                }
+            }
+
             var grpcResponse = client.DeleteAnnotationAsync(grpcRequest, GetCallOptions(context, cancellationToken));
             var result = await grpcResponse.ResponseAsync.ConfigureAwait(false);
 

--- a/src/DataCore.Adapter.Json/EventMessageConverter.cs
+++ b/src/DataCore.Adapter.Json/EventMessageConverter.cs
@@ -18,6 +18,7 @@ namespace DataCore.Adapter.Json {
             }
 
             string id = null;
+            string topic = null;
             DateTime utcEventTime = default;
             EventPriority priority = EventPriority.Unknown;
             string category = null;
@@ -36,6 +37,9 @@ namespace DataCore.Adapter.Json {
 
                 if (string.Equals(propertyName, nameof(EventMessage.Id), StringComparison.OrdinalIgnoreCase)) {
                     id = JsonSerializer.Deserialize<string>(ref reader, options);
+                }
+                else if (string.Equals(propertyName, nameof(EventMessage.Topic), StringComparison.OrdinalIgnoreCase)) {
+                    topic = JsonSerializer.Deserialize<string>(ref reader, options);
                 }
                 else if (string.Equals(propertyName, nameof(EventMessage.UtcEventTime), StringComparison.OrdinalIgnoreCase)) {
                     utcEventTime = JsonSerializer.Deserialize<DateTime>(ref reader, options);
@@ -57,7 +61,7 @@ namespace DataCore.Adapter.Json {
                 }
             }
 
-            return EventMessage.Create(id, utcEventTime, priority, category, message, properties);
+            return EventMessage.Create(id, topic, utcEventTime, priority, category, message, properties);
         }
 
 
@@ -70,6 +74,7 @@ namespace DataCore.Adapter.Json {
 
             writer.WriteStartObject();
             WritePropertyValue(writer, nameof(EventMessage.Id), value.Id, options);
+            WritePropertyValue(writer, nameof(EventMessage.Topic), value.Topic, options);
             WritePropertyValue(writer, nameof(EventMessage.UtcEventTime), value.UtcEventTime, options);
             WritePropertyValue(writer, nameof(EventMessage.Priority), value.Priority, options);
             WritePropertyValue(writer, nameof(EventMessage.Category), value.Category, options);

--- a/src/DataCore.Adapter.Json/EventMessageWithCursorPositionConverter.cs
+++ b/src/DataCore.Adapter.Json/EventMessageWithCursorPositionConverter.cs
@@ -18,6 +18,7 @@ namespace DataCore.Adapter.Json {
             }
 
             string id = null;
+            string topic = null;
             DateTime utcEventTime = default;
             EventPriority priority = EventPriority.Unknown;
             string category = null;
@@ -37,6 +38,9 @@ namespace DataCore.Adapter.Json {
 
                 if (string.Equals(propertyName, nameof(EventMessageWithCursorPosition.Id), StringComparison.OrdinalIgnoreCase)) {
                     id = JsonSerializer.Deserialize<string>(ref reader, options);
+                }
+                else if (string.Equals(propertyName, nameof(EventMessageWithCursorPosition.Topic), StringComparison.OrdinalIgnoreCase)) {
+                    topic = JsonSerializer.Deserialize<string>(ref reader, options);
                 }
                 else if (string.Equals(propertyName, nameof(EventMessageWithCursorPosition.UtcEventTime), StringComparison.OrdinalIgnoreCase)) {
                     utcEventTime = JsonSerializer.Deserialize<DateTime>(ref reader, options);
@@ -61,7 +65,7 @@ namespace DataCore.Adapter.Json {
                 }
             }
 
-            return EventMessageWithCursorPosition.Create(id, utcEventTime, priority, category, message, properties, cursorPosition);
+            return EventMessageWithCursorPosition.Create(id, topic, utcEventTime, priority, category, message, properties, cursorPosition);
         }
 
 
@@ -74,6 +78,7 @@ namespace DataCore.Adapter.Json {
 
             writer.WriteStartObject();
             WritePropertyValue(writer, nameof(EventMessageWithCursorPosition.Id), value.Id, options);
+            WritePropertyValue(writer, nameof(EventMessageWithCursorPosition.Topic), value.Topic, options);
             WritePropertyValue(writer, nameof(EventMessageWithCursorPosition.UtcEventTime), value.UtcEventTime, options);
             WritePropertyValue(writer, nameof(EventMessageWithCursorPosition.Priority), value.Priority, options);
             WritePropertyValue(writer, nameof(EventMessageWithCursorPosition.Category), value.Category, options);

--- a/src/DataCore.Adapter/Events/EventMessageBuilder.cs
+++ b/src/DataCore.Adapter/Events/EventMessageBuilder.cs
@@ -16,6 +16,11 @@ namespace DataCore.Adapter.Events {
         private string _id = Guid.NewGuid().ToString();
 
         /// <summary>
+        /// The event message topic (e.g. the MQTT channel that emitted the message).
+        /// </summary>
+        private string _topic;
+
+        /// <summary>
         /// The UTC event timestamp.
         /// </summary>
         private DateTime _utcEventTime = DateTime.UtcNow;
@@ -56,6 +61,7 @@ namespace DataCore.Adapter.Events {
         /// </param>
         private EventMessageBuilder(EventMessage existing) {
             _id = existing.Id;
+            _topic = existing.Topic;
             _utcEventTime = existing.UtcEventTime;
             _priority = existing.Priority;
             _category = existing.Category;
@@ -107,7 +113,7 @@ namespace DataCore.Adapter.Events {
         ///   A new <see cref="EventMessage"/> object.
         /// </returns>
         public EventMessage Build() {
-            return EventMessage.Create(_id, _utcEventTime, _priority, _category, _message, _properties);
+            return EventMessage.Create(_id, _topic, _utcEventTime, _priority, _category, _message, _properties);
         }
 
 
@@ -127,6 +133,7 @@ namespace DataCore.Adapter.Events {
         public EventMessageWithCursorPosition Build(string cursorPosition) {
             return EventMessageWithCursorPosition.Create(
                 _id, 
+                _topic,
                 _utcEventTime, 
                 _priority, 
                 _category, 
@@ -152,6 +159,21 @@ namespace DataCore.Adapter.Events {
         /// </remarks>
         public EventMessageBuilder WithId(string id) {
             _id = id ?? Guid.NewGuid().ToString();
+            return this;
+        }
+
+
+        /// <summary>
+        /// Updates the topic (i.e. the source channel) for the event.
+        /// </summary>
+        /// <param name="topic">
+        ///   The topic name.
+        /// </param>
+        /// <returns>
+        ///   The updated <see cref="EventMessageBuilder"/>.
+        /// </returns>
+        public EventMessageBuilder WithTopic(string topic) {
+            _topic = topic;
             return this;
         }
 

--- a/src/DataCore.Adapter/Events/EventMessagePushWithTopics.cs
+++ b/src/DataCore.Adapter/Events/EventMessagePushWithTopics.cs
@@ -1,0 +1,641 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Threading;
+using System.Threading.Channels;
+using System.Threading.Tasks;
+
+using DataCore.Adapter.Common;
+using DataCore.Adapter.Diagnostics;
+
+using IntelligentPlant.BackgroundTasks;
+
+using Microsoft.Extensions.Logging;
+
+namespace DataCore.Adapter.Events {
+
+    /// <summary>
+    /// Implements <see cref="IEventMessagePushWithTopics"/>.
+    /// </summary>
+    public class EventMessagePushWithTopics : IEventMessagePushWithTopics, IFeatureHealthCheck, IDisposable {
+
+        /// <summary>
+        /// The <see cref="EventMessage"/> property name that contains the event's topic name.
+        /// </summary>
+        public const string EventTopicPropertyName = "Topic";
+
+        /// <summary>
+        /// Indicates if the object has been disposed.
+        /// </summary>
+        private bool _isDisposed;
+
+        /// <summary>
+        /// The scheduler to use when running background tasks.
+        /// </summary>
+        protected IBackgroundTaskService Scheduler { get; }
+
+        /// <summary>
+        /// The logger.
+        /// </summary>
+        protected ILogger Logger { get; }
+
+        /// <summary>
+        /// Fires when the <see cref="EventMessagePushWithTopics"/> is disposed.
+        /// </summary>
+        private readonly CancellationTokenSource _disposedTokenSource = new CancellationTokenSource();
+
+        /// <summary>
+        /// A cancellation token that will fire when the object is disposed.
+        /// </summary>
+        protected CancellationToken DisposedToken => _disposedTokenSource.Token;
+
+        /// <summary>
+        /// Feature options.
+        /// </summary>
+        private readonly EventMessagePushWithTopicsOptions _options;
+
+        /// <summary>
+        /// Channel that is used to publish new event messages. This is a single-consumer channel; the 
+        /// consumer thread will then re-publish to subscribers as required.
+        /// </summary>
+        private readonly Channel<(EventMessage Value, EventMessageSubscriptionWithTopicsBase[] Subscribers)> _masterChannel = Channel.CreateUnbounded<(EventMessage, EventMessageSubscriptionWithTopicsBase[])>(new UnboundedChannelOptions() {
+            AllowSynchronousContinuations = false,
+            SingleReader = true,
+            SingleWriter = false
+        });
+
+        /// <summary>
+        /// Channel that is used to publish changes to subscribed topics.
+        /// </summary>
+        private readonly Channel<(string Topic, bool Added, TaskCompletionSource<bool> Processed)> _topicSubscriptionChangesChannel = Channel.CreateUnbounded<(string, bool, TaskCompletionSource<bool>)>(new UnboundedChannelOptions() {
+            AllowSynchronousContinuations = false,
+            SingleReader = true,
+            SingleWriter = true
+        });
+
+        /// <summary>
+        /// All subscriptions.
+        /// </summary>
+        private readonly HashSet<Subscription> _subscriptions = new HashSet<Subscription>();
+
+        /// <summary>
+        /// Maps from topic name to the subscriber count for that topic.
+        /// </summary>
+        private readonly Dictionary<string, int> _subscriberCount = new Dictionary<string, int>(StringComparer.OrdinalIgnoreCase);
+
+        /// <summary>
+        /// For protecting access to <see cref="_subscriptions"/> and <see cref="_subscriberCount"/>.
+        /// </summary>
+        private readonly ReaderWriterLockSlim _subscriptionsLock = new ReaderWriterLockSlim(LockRecursionPolicy.SupportsRecursion);
+
+        /// <summary>
+        /// Indicates if the subscription manager currently holds any subscriptions.
+        /// </summary>
+        protected bool HasSubscriptions { get; private set; }
+
+        /// <summary>
+        /// Indicates if the subscription manager holds any active subscriptions. If your adapter uses 
+        /// a forward-only cursor that you do not want to advance when only passive listeners are 
+        /// attached to the adapter, you can use this property to identify if any active listeners are 
+        /// attached.
+        /// </summary>
+        protected bool HasActiveSubscriptions { get; private set; }
+
+        /// <summary>
+        /// Emits all values that are published to the internal master channel.
+        /// </summary>
+        public event Action<EventMessage> Publish;
+
+
+        /// <summary>
+        /// Creates a new <see cref="EventMessagePushWithTopics"/> object.
+        /// </summary>
+        /// <param name="options">
+        ///   The feature options.
+        /// </param>
+        /// <param name="scheduler">
+        ///   The task scheduler to use when running background operations.
+        /// </param>
+        /// <param name="logger">
+        ///   The logger for the subscription manager.
+        /// </param>
+        public EventMessagePushWithTopics(EventMessagePushWithTopicsOptions options, IBackgroundTaskService scheduler, ILogger logger) {
+            _options = options ?? new EventMessagePushWithTopicsOptions();
+            Scheduler = scheduler ?? BackgroundTaskService.Default;
+            Logger = logger ?? Microsoft.Extensions.Logging.Abstractions.NullLogger.Instance;
+
+            Scheduler.QueueBackgroundWorkItem(ProcessTopicSubscriptionChangesChannel, _disposedTokenSource.Token);
+            Scheduler.QueueBackgroundWorkItem(ProcessPublishToSubscribersChannel, _disposedTokenSource.Token);
+        }
+
+
+        /// <summary>
+        /// Invoked by a subscription object when a topic is added to the subscription.
+        /// </summary>
+        /// <param name="subscription">
+        ///   The subscription.
+        /// </param>
+        /// <param name="topic">
+        ///   The topic.
+        /// </param>
+        private async Task OnTopicAddedToSubscription(Subscription subscription, string topic) {
+            if (subscription == null || string.IsNullOrWhiteSpace(topic)) {
+                return;
+            }
+
+            var isNewSubscription = false;
+            TaskCompletionSource<bool> processed = null;
+
+            _subscriptionsLock.EnterWriteLock();
+            try {
+                if (!_subscriberCount.TryGetValue(topic, out var subscriberCount)) {
+                    subscriberCount = 0;
+                    isNewSubscription = true;
+                }
+
+                _subscriberCount[topic] = ++subscriberCount;
+                if (isNewSubscription) {
+                    processed = new TaskCompletionSource<bool>();
+                    _topicSubscriptionChangesChannel.Writer.TryWrite((topic, true, processed));
+                }
+            }
+            finally {
+                _subscriptionsLock.ExitWriteLock();
+            }
+
+            if (processed == null) {
+                return;
+            }
+
+            // Wait for change to be processed.
+            await processed.Task.WithCancellation(DisposedToken).ConfigureAwait(false);
+        }
+
+
+        /// <summary>
+        /// Invoked by a subscription object when a topic is removed from a subscription.
+        /// </summary>
+        /// <param name="subscription">
+        ///   The subscription.
+        /// </param>
+        /// <param name="topic">
+        ///   The topic.
+        /// </param>
+        private async Task OnTopicRemovedFromSubscription(Subscription subscription, string topic) {
+            if (subscription == null || string.IsNullOrWhiteSpace(topic)) {
+                return;
+            }
+
+            TaskCompletionSource<bool> processed = null;
+
+            _subscriptionsLock.EnterWriteLock();
+            try {
+                if (!_subscriberCount.TryGetValue(topic, out var subscriberCount)) {
+                    // No subscribers
+                    return;
+                }
+
+                --subscriberCount;
+
+                if (subscriberCount == 0) {
+                    // No subscribers remaining.
+                    _subscriberCount.Remove(topic);
+                    processed = new TaskCompletionSource<bool>();
+                    _topicSubscriptionChangesChannel.Writer.TryWrite((topic, false, processed));
+                }
+                else {
+                    _subscriberCount[topic] = subscriberCount;
+                }
+            }
+            finally {
+                _subscriptionsLock.ExitWriteLock();
+            }
+
+            if (processed == null) {
+                return;
+            }
+
+            // Wait for change to be processed.
+            await processed.Task.WithCancellation(DisposedToken).ConfigureAwait(false);
+        }
+
+
+        /// <summary>
+        /// Invoked when a subscription has been cancelled.
+        /// </summary>
+        /// <param name="subscription">
+        ///   The subscription.
+        /// </param>
+        private void OnSubscriptionCancelled(Subscription subscription) {
+            _subscriptionsLock.EnterWriteLock();
+            try {
+                _subscriptions.Remove(subscription);
+                foreach (var topic in subscription.GetSubscribedTopics()) {
+                    if (!_subscriberCount.TryGetValue(topic, out var subscriberCount)) {
+                        continue;
+                    }
+
+                    --subscriberCount;
+
+                    if (subscriberCount == 0) {
+                        _subscriberCount.Remove(topic);
+                        _topicSubscriptionChangesChannel.Writer.TryWrite((topic, false, null));
+                    }
+                    else {
+                        _subscriberCount[topic] = subscriberCount;
+                    }
+                }
+            }
+            finally {
+                _subscriptionsLock.ExitWriteLock();
+            }
+        }
+
+
+        /// <summary>
+        /// Called when the number of subscribers for a topic changes from zero to one.
+        /// </summary>
+        /// <param name="topic">
+        ///   The topic.
+        /// </param>
+        protected virtual void OnTopicAddedToSubscription(string topic) {
+            _options.OnTopicSubscriptionAdded?.Invoke(topic);
+        }
+
+
+        /// <summary>
+        /// Called when the number of subscribers for a topic changes from one to zero.
+        /// </summary>
+        /// <param name="topic">
+        ///   The topic.
+        /// </param>
+        protected virtual void OnTopicRemovedFromSubscription(string topic) {
+            _options.OnTopicSubscriptionRemoved?.Invoke(topic);
+        }
+
+
+        /// <summary>
+        /// Starts a long-running that that will read and process subscription changes published 
+        /// to <see cref="_topicSubscriptionChangesChannel"/>.
+        /// </summary>
+        /// <param name="cancellationToken">
+        ///   A cancellation token that will fire when the task should exit.
+        /// </param>
+        /// <returns>
+        ///   A long-running task.
+        /// </returns>
+        private async Task ProcessTopicSubscriptionChangesChannel(CancellationToken cancellationToken) {
+            while (!cancellationToken.IsCancellationRequested) {
+                if (!await _topicSubscriptionChangesChannel.Reader.WaitToReadAsync(cancellationToken).ConfigureAwait(false)) {
+                    break;
+                }
+
+                if (!_topicSubscriptionChangesChannel.Reader.TryRead(out var change) || string.IsNullOrWhiteSpace(change.Topic)) {
+                    continue;
+                }
+
+                try {
+                    if (change.Added) {
+                        OnTopicAddedToSubscription(change.Topic);
+                    }
+                    else {
+                        OnTopicRemovedFromSubscription(change.Topic);
+                    }
+
+                    if (change.Processed != null) {
+                        change.Processed.TrySetResult(true);
+                    }
+                }
+#pragma warning disable CA1031 // Do not catch general exception types
+                catch (Exception e) {
+#pragma warning restore CA1031 // Do not catch general exception types
+                    if (change.Processed != null) {
+                        change.Processed.TrySetException(e);
+                    }
+
+                    Logger.LogError(
+                        e,
+                        Resources.Log_ErrorWhileProcessingSubscriptionTopicChange,
+                        change.Topic,
+                        change.Added
+                            ? SubscriptionUpdateAction.Subscribe
+                            : SubscriptionUpdateAction.Unsubscribe
+                    );
+                }
+            }
+        }
+
+
+        /// <summary>
+        /// Starts a long-running task that will read values published to <see cref="_masterChannel"/> 
+        /// and re-publish them to subscribers for the topic.
+        /// </summary>
+        /// <param name="cancellationToken">
+        ///   A cancellation token that will fire when the task should exit.
+        /// </param>
+        /// <returns>
+        ///   A long-running task.
+        /// </returns>
+        private async Task ProcessPublishToSubscribersChannel(CancellationToken cancellationToken) {
+            while (!cancellationToken.IsCancellationRequested) {
+                if (!await _masterChannel.Reader.WaitToReadAsync(cancellationToken).ConfigureAwait(false)) {
+                    break;
+                }
+
+                if (!_masterChannel.Reader.TryRead(out var item)) {
+                    continue;
+                }
+
+                Publish?.Invoke(item.Value);
+
+                foreach (var subscriber in item.Subscribers) {
+                    try {
+                        var success = await subscriber.ValueReceived(item.Value, cancellationToken).ConfigureAwait(false);
+                        if (!success) {
+                            Logger.LogTrace(Resources.Log_PublishToSubscriberWasUnsuccessful, subscriber.Context?.ConnectionId);
+                        }
+                    }
+                    catch (OperationCanceledException) { }
+#pragma warning disable CA1031 // Do not catch general exception types
+                    catch (Exception e) {
+#pragma warning restore CA1031 // Do not catch general exception types
+                        Logger.LogError(e, Resources.Log_PublishToSubscriberThrewException, subscriber.Context?.ConnectionId);
+                    }
+                }
+            }
+        }
+
+
+        /// <summary>
+        /// Creates a new subscription.
+        /// </summary>
+        /// <param name="context">
+        ///   The <see cref="IAdapterCallContext"/> for the subscriber.
+        /// </param>
+        /// <param name="request">
+        ///   The subscription request settings.
+        /// </param>
+        /// <returns>
+        ///   The new subscription.
+        /// </returns>
+        protected virtual Subscription CreateSubscription(IAdapterCallContext context, CreateEventMessageSubscriptionRequest request) {
+            return new Subscription(context, request, this);
+        }
+
+
+        /// <summary>
+        /// Invoked when a subscription is created.
+        /// </summary>
+        protected virtual void OnSubscriptionAdded() { }
+
+
+        /// <summary>
+        /// Invoked when a subscription is removed.
+        /// </summary>
+        /// <returns>
+        ///   A task that will perform subscription-related activities.
+        /// </returns>
+        protected virtual void OnSubscriptionRemoved() { }
+
+
+        /// <summary>
+        /// Publishes a value to subscribers.
+        /// </summary>
+        /// <param name="value">
+        ///   The value to publish.
+        /// </param>
+        /// <param name="cancellationToken">
+        ///   The cancellation token for the operation.
+        /// </param>
+        /// <returns>
+        ///   A <see cref="ValueTask{TResult}"/> that will return a <see cref="bool"/> indicating 
+        ///   if the value was published to subscribers.
+        /// </returns>
+        /// <exception cref="ArgumentNullException">
+        ///   <paramref name="value"/> is <see langword="null"/>.
+        /// </exception>
+        public async ValueTask<bool> ValueReceived(EventMessage value, CancellationToken cancellationToken = default) {
+            if (value == null) {
+                throw new ArgumentNullException(nameof(value));
+            }
+
+            EventMessageSubscriptionWithTopicsBase[] subscribers;
+
+            _subscriptionsLock.EnterReadLock();
+            try {
+                subscribers = _subscriptions.Where(x => x.IsSubscribed(value)).ToArray();
+            }
+            finally {
+                _subscriptionsLock.ExitReadLock();
+            }
+
+            if (!subscribers.Any()) {
+                return false;
+            }
+
+            try {
+                using (var ctSource = CancellationTokenSource.CreateLinkedTokenSource(cancellationToken, _disposedTokenSource.Token)) {
+                    await _masterChannel.Writer.WaitToWriteAsync(ctSource.Token).ConfigureAwait(false);
+                    return _masterChannel.Writer.TryWrite((value, subscribers));
+                }
+            }
+            catch (OperationCanceledException) {
+                if (cancellationToken.IsCancellationRequested) {
+                    // Cancellation token provided by the caller has fired; rethrow the exception.
+                    throw;
+                }
+
+                // The stream manager is being disposed.
+                return false;
+            }
+        }
+
+
+        public async Task<IEventMessageSubscriptionWithTopics> Subscribe(
+            IAdapterCallContext context,
+            CreateEventMessageSubscriptionRequest request
+        ) {
+            var subscription = CreateSubscription(context, request ?? new CreateEventMessageSubscriptionRequest());
+
+            bool added;
+            _subscriptionsLock.EnterWriteLock();
+            try {
+                added = _subscriptions.Add(subscription);
+                if (added) {
+                    HasSubscriptions = _subscriptions.Count > 0;
+                    HasActiveSubscriptions = _subscriptions.Any(x => x.SubscriptionType == EventMessageSubscriptionType.Active);
+                }
+            }
+            finally {
+                _subscriptionsLock.ExitWriteLock();
+            }
+
+            if (added) {
+                await subscription.Start().ConfigureAwait(false);
+                OnSubscriptionAdded();
+            }
+
+            return subscription;
+        }
+
+
+        /// <inheritdoc/>
+        public Task<HealthCheckResult> CheckFeatureHealthAsync(IAdapterCallContext context, CancellationToken cancellationToken) {
+            Subscription[] subscriptions;
+            int subscribedTagCount;
+
+            _subscriptionsLock.EnterReadLock();
+            try {
+                subscriptions = _subscriptions.ToArray();
+                subscribedTagCount = _subscriberCount.Count;
+            }
+            finally {
+                _subscriptionsLock.ExitReadLock();
+            }
+
+
+            var result = HealthCheckResult.Healthy(nameof(EventMessagePushWithTopics), data: new Dictionary<string, string>() {
+                { Resources.HealthChecks_Data_SubscriberCount, subscriptions.Length.ToString(context?.CultureInfo) },
+                { Resources.HealthChecks_Data_TopicCount, subscribedTagCount.ToString(context?.CultureInfo) }
+            });
+
+            return Task.FromResult(result);
+        }
+
+
+        /// <inheritdoc/>
+        public void Dispose() {
+            Dispose(true);
+            GC.SuppressFinalize(this);
+        }
+
+
+        /// <summary>
+        /// Class finalizer.
+        /// </summary>
+        ~EventMessagePushWithTopics() {
+            Dispose(false);
+        }
+
+
+        /// <summary>
+        /// Releases resources held by the <see cref="SnapshotTagValuePush"/>.
+        /// </summary>
+        /// <param name="disposing">
+        ///   <see langword="true"/> if the object is being disposed, or <see langword="false"/> 
+        ///   if it is being finalized.
+        /// </param>
+        protected virtual void Dispose(bool disposing) {
+            if (_isDisposed) {
+                return;
+            }
+
+            if (disposing) {
+                _isDisposed = true;
+                _masterChannel.Writer.TryComplete();
+                _topicSubscriptionChangesChannel.Writer.TryComplete();
+                _disposedTokenSource.Cancel();
+                _disposedTokenSource.Dispose();
+                _subscriptionsLock.EnterWriteLock();
+                try {
+                    _subscriberCount.Clear();
+                    foreach (var subscription in _subscriptions.ToArray()) {
+                        subscription.Dispose();
+                    }
+                    _subscriptions.Clear();
+                }
+                finally {
+                    _subscriptionsLock.ExitWriteLock();
+                    _subscriptionsLock.Dispose();
+                }
+            }
+        }
+
+
+        #region [ Inner Types ]
+
+        /// <summary>
+        /// Implements <see cref="EventMessageSubscriptionBase"/>.
+        /// </summary>
+        public class Subscription : EventMessageSubscriptionWithTopicsBase {
+
+            /// <summary>
+            /// The owning feature.
+            /// </summary>
+            private readonly EventMessagePushWithTopics _feature;
+
+
+            /// <summary>
+            /// Creates a new <see cref="Subscription"/> object.
+            /// </summary>
+            /// <param name="context">
+            ///   The adapter call context for the subscriber.
+            /// </param>
+            /// <param name="subscriptionType">
+            ///   Indicates if the subscription is an active or passive event listener.
+            /// </param>
+            /// <param name="feature">
+            ///   The subscription manager that the subscription is attached to.
+            /// </param>
+            public Subscription(
+                IAdapterCallContext context,
+                CreateEventMessageSubscriptionRequest request,
+                EventMessagePushWithTopics feature
+            ) : base(
+                context,
+                feature?._options?.AdapterId,
+                request.SubscriptionType
+            ) {
+                _feature = feature ?? throw new ArgumentNullException(nameof(feature));
+            }
+
+
+            /// <inheritdoc/>
+            protected override Task OnTopicAdded(string topic) {
+                return _feature.OnTopicAddedToSubscription(this, topic);
+            }
+
+
+            /// <inheritdoc/>
+            protected override Task OnTopicRemoved(string topic) {
+                return _feature.OnTopicRemovedFromSubscription(this, topic);
+            }
+
+
+            protected override void OnCancelled() {
+                base.OnCancelled();
+                _feature.OnSubscriptionCancelled(this);
+            }
+
+        }
+
+        #endregion
+
+    }
+
+
+    /// <summary>
+    /// Options for <see cref="SnapshotTagValuePush"/>
+    /// </summary>
+    public class EventMessagePushWithTopicsOptions {
+
+        /// <summary>
+        /// The adapter name to use when creating subscription IDs.
+        /// </summary>
+        public string AdapterId { get; set; }
+
+        /// <summary>
+        /// A delegate that is invoked when the number of subscribers for a topic changes from zero 
+        /// to one.
+        /// </summary>
+        public Action<string> OnTopicSubscriptionAdded { get; set; }
+
+        /// <summary>
+        /// A delegate that is invoked when the number of subscribers for a topic changes from one 
+        /// to zero.
+        /// </summary>
+        public Action<string> OnTopicSubscriptionRemoved { get; set; }
+
+    }
+
+}

--- a/src/DataCore.Adapter/Events/EventMessageSubscriptionWithTopicsBase.cs
+++ b/src/DataCore.Adapter/Events/EventMessageSubscriptionWithTopicsBase.cs
@@ -1,0 +1,93 @@
+﻿using System.Threading.Tasks;
+
+namespace DataCore.Adapter.Events {
+
+    /// <summary>
+    /// Base implementation of <see cref="IEventMessageSubscriptionWithTopics"/>.
+    /// </summary>
+    /// <typeparam name="T">
+    ///   The type that topic names will be resolved to when added to the subscription.
+    /// </typeparam>
+    public abstract class EventMessageSubscriptionWithTopicsBase<T> : AdapterSubscriptionWithTopics<EventMessage, T>, IEventMessageSubscriptionWithTopics where T : class {
+
+        /// <summary>
+        /// The subscription type.
+        /// </summary>
+        public EventMessageSubscriptionType SubscriptionType { get; }
+
+
+        /// <summary>
+        /// Creates a new <see cref="EventMessageSubscriptionWithTopicsBase{T}"/> object.
+        /// </summary>
+        /// <param name="context">
+        ///   The <see cref="IAdapterCallContext"/> for the subscription owner.
+        /// </param>
+        /// <param name="id">
+        ///   An identifier for the subscription (e.g. the ID of the adapter that the subscription 
+        ///   is being created on). The value does not have to be unique; a fully-qualified 
+        ///   identifier will be generated using this value.
+        /// </param>
+        /// <param name="subscriptionType">
+        ///   The subscription type (active or passive).
+        /// </param>
+        protected EventMessageSubscriptionWithTopicsBase(
+            IAdapterCallContext context,
+            string id,
+            EventMessageSubscriptionType subscriptionType
+        ) : base(
+            context,
+            id
+        ) {
+            SubscriptionType = subscriptionType;
+        }
+
+
+        /// <inheritdoc/>
+        protected override string GetTopicNameForValue(EventMessage value) {
+            return value?.Topic;
+        }
+
+
+        /// <inheritdoc/>
+        protected override void OnCancelled() {
+            // Do nothing.
+        }
+
+    }
+
+
+    /// <summary>
+    /// Base implementation of <see cref="IEventMessageSubscriptionWithTopics"/> that does not 
+    /// need to parse a topic name into another type.
+    /// </summary>
+    public abstract class EventMessageSubscriptionWithTopicsBase : EventMessageSubscriptionWithTopicsBase<string> {
+
+        /// <summary>
+        /// Creates a new <see cref="EventMessageSubscriptionWithTopicsBase"/> object.
+        /// </summary>
+        /// <param name="context">
+        ///   The <see cref="IAdapterCallContext"/> for the subscription owner.
+        /// </param>
+        /// <param name="id">
+        ///   An identifier for the subscription (e.g. the ID of the adapter that the subscription 
+        ///   is being created on). The value does not have to be unique; a fully-qualified 
+        ///   identifier will be generated using this value.
+        /// </param>
+        /// <param name="subscriptionType">
+        ///   The subscription type (active or passive).
+        /// </param>
+        protected EventMessageSubscriptionWithTopicsBase(
+            IAdapterCallContext context,
+            string id,
+            EventMessageSubscriptionType subscriptionType
+        ) : base(context, id, subscriptionType) { }
+
+
+        /// <inheritdoc/>
+        protected sealed override ValueTask<string> ResolveTopic(IAdapterCallContext context, string topic) {
+            return new ValueTask<string>(topic);
+        }
+
+    }
+
+}

--- a/src/DataCore.Adapter/Resources.Designer.cs
+++ b/src/DataCore.Adapter/Resources.Designer.cs
@@ -286,6 +286,15 @@ namespace DataCore.Adapter {
         }
         
         /// <summary>
+        ///   Looks up a localized string similar to Topic Count.
+        /// </summary>
+        internal static string HealthChecks_Data_TopicCount {
+            get {
+                return ResourceManager.GetString("HealthChecks_Data_TopicCount", resourceCulture);
+            }
+        }
+        
+        /// <summary>
         ///   Looks up a localized string similar to User.
         /// </summary>
         internal static string HealthChecks_Data_UserName {
@@ -417,6 +426,15 @@ namespace DataCore.Adapter {
         internal static string Log_ErrorWhileProcessingSnapshotSubscriptionChange {
             get {
                 return ResourceManager.GetString("Log_ErrorWhileProcessingSnapshotSubscriptionChange", resourceCulture);
+            }
+        }
+        
+        /// <summary>
+        ///   Looks up a localized string similar to An error occurred while processing a subscription change: Topic = {topic}, Action = {action}.
+        /// </summary>
+        internal static string Log_ErrorWhileProcessingSubscriptionTopicChange {
+            get {
+                return ResourceManager.GetString("Log_ErrorWhileProcessingSubscriptionTopicChange", resourceCulture);
             }
         }
         

--- a/src/DataCore.Adapter/Resources.resx
+++ b/src/DataCore.Adapter/Resources.resx
@@ -196,6 +196,9 @@
   <data name="HealthChecks_Data_TagCount" xml:space="preserve">
     <value>Tag Count</value>
   </data>
+  <data name="HealthChecks_Data_TopicCount" xml:space="preserve">
+    <value>Topic Count</value>
+  </data>
   <data name="HealthChecks_Data_UserName" xml:space="preserve">
     <value>User</value>
   </data>
@@ -241,6 +244,9 @@
   </data>
   <data name="Log_ErrorWhileProcessingSnapshotSubscriptionChange" xml:space="preserve">
     <value>An error occurred while processing a subscription change: Tag = {tag}, Action = {action}</value>
+  </data>
+  <data name="Log_ErrorWhileProcessingSubscriptionTopicChange" xml:space="preserve">
+    <value>An error occurred while processing a subscription change: Topic = {topic}, Action = {action}</value>
   </data>
   <data name="Log_InMemoryEventMessageManager_EvictedMessage" xml:space="preserve">
     <value>Evicted event message {id} with cursor position {cursorPosition} and timestamp {timestamp}.</value>

--- a/src/Protos/datacore/adapter/AssetModelBrowserService.proto
+++ b/src/Protos/datacore/adapter/AssetModelBrowserService.proto
@@ -19,12 +19,14 @@ message BrowseAssetModelNodesRequest {
     int32 page_size = 2;
     int32 page = 3;
     string parent_id = 4;
+    map<string, string> properties = 5;
 }
 
 
 message GetAssetModelNodesRequest {
     string adapter_id = 1;
     repeated string nodes = 2;
+    map<string, string> properties = 3;
 }
 
 
@@ -34,4 +36,5 @@ message FindAssetModelNodesRequest {
     int32 page = 3;
     string name = 4;
     string description = 5;
+    map<string, string> properties = 6;
 }

--- a/src/Protos/datacore/adapter/EventsService.proto
+++ b/src/Protos/datacore/adapter/EventsService.proto
@@ -11,7 +11,10 @@ option csharp_namespace = "DataCore.Adapter.Grpc";
 service EventsService {
     // Push 
     rpc CreateEventPushChannel(CreateEventPushChannelRequest) returns (stream EventMessage);
-    
+    rpc CreateEventTopicPushSubscription(CreateEventTopicPushSubscriptionRequest) returns (CreateEventTopicPushSubscriptionResponse);
+    rpc DeleteEventTopicPushSubscription(DeleteEventTopicPushSubscriptionRequest) returns (DeleteEventTopicPushSubscriptionResponse);
+    rpc CreateEventTopicPushChannel(CreateEventTopicPushChannelRequest) returns (stream EventMessage);
+
     // Polling
     rpc GetEventMessagesForTimeRange(GetEventMessagesForTimeRangeRequest) returns (stream EventMessage);
     rpc GetEventMessagesUsingCursorPosition(GetEventMessagesUsingCursorPositionRequest) returns (stream EventMessageWithCursorPosition);
@@ -28,6 +31,37 @@ message CreateEventPushChannelRequest {
 }
 
 
+message CreateEventTopicPushSubscriptionRequest {
+    string session_id = 1;
+    string adapter_id = 2;
+    EventSubscriptionType subscription_type = 3;
+    map<string,string> properties = 4;
+}
+
+
+message CreateEventTopicPushSubscriptionResponse {
+    string subscription_id = 1;
+}
+
+
+message DeleteEventTopicPushSubscriptionRequest {
+    string session_id = 1;
+    string subscription_id = 2;
+}
+
+
+message DeleteEventTopicPushSubscriptionResponse {
+    bool success = 1;
+}
+
+
+message CreateEventTopicPushChannelRequest {
+    string session_id = 1;
+    string subscription_id = 2;
+    string topic = 3;
+}
+
+
 message GetEventMessagesForTimeRangeRequest {
     string adapter_id = 1;
     EventReadDirection direction = 2;
@@ -36,6 +70,7 @@ message GetEventMessagesForTimeRangeRequest {
     map<string,string> properties = 6;
     int32 page_size = 7;
     int32 page = 8;
+    repeated string topics = 9;
 }
 
 
@@ -45,4 +80,5 @@ message GetEventMessagesUsingCursorPositionRequest {
     string cursor_position = 4;
     map<string,string> properties = 5;
     int32 page_size = 6;
+    repeated string topics = 7;
 }

--- a/src/Protos/datacore/adapter/TagSearchService.proto
+++ b/src/Protos/datacore/adapter/TagSearchService.proto
@@ -24,6 +24,7 @@ message FindTagsRequest {
     string units = 6;
     string label = 7;
     map<string, string> other = 8;
+    map<string, string> properties = 9;
 }
 
 
@@ -31,6 +32,7 @@ message FindTagsRequest {
 message GetTagsRequest {
     string adapter_id = 1;
     repeated string tags = 2;
+    map<string, string> properties = 3;
 }
 
 
@@ -39,4 +41,5 @@ message GetTagPropertiesRequest {
     string adapter_id = 1;
     int32 page_size = 2;
     int32 page = 3;
+    map<string, string> properties = 4;
 }

--- a/src/Protos/datacore/adapter/TagValueAnnotationsService.proto
+++ b/src/Protos/datacore/adapter/TagValueAnnotationsService.proto
@@ -23,6 +23,7 @@ message ReadAnnotationsRequest {
     google.protobuf.Timestamp utc_start_time = 3;
     google.protobuf.Timestamp utc_end_time = 4;
     map<string, string> properties = 5;
+    int32 max_annotation_count = 6;
 }
 message ReadAnnotationRequest {
     string adapter_id = 1;
@@ -34,8 +35,7 @@ message CreateAnnotationRequest {
     string adapter_id = 1;
     string tag = 2;
     TagValueAnnotationBase annotation = 3;
-    int32 max_annotation_count = 4;
-    map<string, string> properties = 5;
+    map<string, string> properties = 4;
 }
 message UpdateAnnotationRequest {
     string adapter_id = 1;

--- a/src/Protos/datacore/adapter/TagValueAnnotationsService.proto
+++ b/src/Protos/datacore/adapter/TagValueAnnotationsService.proto
@@ -22,25 +22,31 @@ message ReadAnnotationsRequest {
     repeated string tags = 2;
     google.protobuf.Timestamp utc_start_time = 3;
     google.protobuf.Timestamp utc_end_time = 4;
+    map<string, string> properties = 5;
 }
 message ReadAnnotationRequest {
     string adapter_id = 1;
     string tag = 2;
     string annotation_id = 3;
+    map<string, string> properties = 4;
 }
 message CreateAnnotationRequest {
     string adapter_id = 1;
     string tag = 2;
     TagValueAnnotationBase annotation = 3;
+    int32 max_annotation_count = 4;
+    map<string, string> properties = 5;
 }
 message UpdateAnnotationRequest {
     string adapter_id = 1;
     string tag = 2;
     string annotation_id = 3;
     TagValueAnnotationBase annotation = 4;
+    map<string, string> properties = 5;
 }
 message DeleteAnnotationRequest {
     string adapter_id = 1;
     string tag = 2;
     string annotation_id = 3;
+    map<string, string> properties = 4;
 }

--- a/src/Protos/datacore/adapter/Types.proto
+++ b/src/Protos/datacore/adapter/Types.proto
@@ -136,6 +136,7 @@ message EventMessage {
     string category = 4;
     string message = 5;
     repeated AdapterProperty properties = 6;
+    string topic = 7;
 }
 
 

--- a/test/DataCore.Adapter.Tests/ExampleAdapterTests.cs
+++ b/test/DataCore.Adapter.Tests/ExampleAdapterTests.cs
@@ -28,10 +28,11 @@ namespace DataCore.Adapter.Tests {
         }
 
 
-        protected override async Task EmitTestEvent(ExampleAdapter adapter, EventMessageSubscriptionType subscriptionType) {
+        protected override async Task EmitTestEvent(ExampleAdapter adapter, EventMessageSubscriptionType subscriptionType, string topic) {
             await adapter.WriteTestEventMessage(
                 EventMessageBuilder
                     .Create()
+                    .WithTopic(topic)
                     .WithUtcEventTime(DateTime.UtcNow)
                     .WithCategory(TestContext.FullyQualifiedTestClassName)
                     .WithMessage(TestContext.TestName)

--- a/test/DataCore.Adapter.Tests/JsonTests.cs
+++ b/test/DataCore.Adapter.Tests/JsonTests.cs
@@ -421,6 +421,7 @@ namespace DataCore.Adapter.Tests {
             var options = GetOptions();
             var expected = new EventMessage(
                 "Id",
+                TestContext.TestName,
                 DateTime.UtcNow,
                 EventPriority.Medium,
                 "Category",
@@ -435,6 +436,7 @@ namespace DataCore.Adapter.Tests {
             var actual = JsonSerializer.Deserialize<EventMessage>(json, options);
 
             Assert.AreEqual(expected.Id, actual.Id);
+            Assert.AreEqual(expected.Topic, actual.Topic);
             Assert.AreEqual(expected.UtcEventTime, actual.UtcEventTime);
             Assert.AreEqual(expected.Priority, actual.Priority);
             Assert.AreEqual(expected.Category, actual.Category);
@@ -456,6 +458,7 @@ namespace DataCore.Adapter.Tests {
             var options = GetOptions();
             var expected = new EventMessageWithCursorPosition(
                 "Id",
+                TestContext.TestName,
                 DateTime.UtcNow,
                 EventPriority.Medium,
                 "Category",
@@ -471,6 +474,7 @@ namespace DataCore.Adapter.Tests {
             var actual = JsonSerializer.Deserialize<EventMessageWithCursorPosition>(json, options);
 
             Assert.AreEqual(expected.Id, actual.Id);
+            Assert.AreEqual(expected.Topic, actual.Topic);
             Assert.AreEqual(expected.UtcEventTime, actual.UtcEventTime);
             Assert.AreEqual(expected.Priority, actual.Priority);
             Assert.AreEqual(expected.Category, actual.Category);

--- a/test/DataCore.Adapter.Tests/ProxyAdapterTests.cs
+++ b/test/DataCore.Adapter.Tests/ProxyAdapterTests.cs
@@ -51,11 +51,12 @@ namespace DataCore.Adapter.Tests {
         }
 
 
-        protected override async Task EmitTestEvent(TProxy adapter, EventMessageSubscriptionType subscriptionType) {
+        protected override async Task EmitTestEvent(TProxy adapter, EventMessageSubscriptionType subscriptionType, string topic) {
             var eventMessageManager = ServiceProvider.GetService<InMemoryEventMessageStore>();
             
             var msg = EventMessageBuilder
                     .Create()
+                    .WithTopic(topic)
                     .WithUtcEventTime(DateTime.UtcNow)
                     .WithCategory(TestContext.FullyQualifiedTestClassName)
                     .WithMessage(TestContext.TestName)


### PR DESCRIPTION
- Ensure that gRPC proxy and services correctly pass through bespoke query properties to adapter queries.
- Add new `IEventMessagePushWithTopics` feature that allows for event subscriptions to systems such as MQTT brokers and OPC UA servers that expose a topic-based event system.
- `IReadEventMessagesForTimeRange` and `IReadEventMessagesUsingCursor` now include a `Topics` property on their request objects so that adapters for topic-based event systems can optionally choose to filer event history based on the specified topics.