### PR TITLE
Modify templated class names

### DIFF
--- a/examples/ExampleHostedAdapter/MyAdapter.ReadSnapshotTagValues.cs
+++ b/examples/ExampleHostedAdapter/MyAdapter.ReadSnapshotTagValues.cs
@@ -10,7 +10,7 @@ namespace ExampleHostedAdapter {
     //
     // See https://github.com/intelligentplant/AppStoreConnect.Adapters for more details.
 
-    partial class ExampleHostedAdapterImpl : IReadSnapshotTagValues {
+    partial class MyAdapter : IReadSnapshotTagValues {
 
         public async IAsyncEnumerable<TagValueQueryResult> ReadSnapshotTagValues(
             IAdapterCallContext context, 

--- a/examples/ExampleHostedAdapter/MyAdapter.cs
+++ b/examples/ExampleHostedAdapter/MyAdapter.cs
@@ -33,7 +33,7 @@ namespace ExampleHostedAdapter {
         // You can optionally specify a help URL for the adapter type.
         HelpUrl = "https://my-company.com/app-store-connect/adapters/my-adapter/help"
     )]
-    public partial class ExampleHostedAdapterImpl : AdapterBase<ExampleHostedAdapterOptions> {
+    public partial class MyAdapter : AdapterBase<MyAdapterOptions> {
 
         private static readonly AdapterProperty s_tagCreatedAtPropertyDefinition = new AdapterProperty("UTC Created At", DateTime.MinValue, "The UTC creation time for the tag");
 
@@ -46,13 +46,13 @@ namespace ExampleHostedAdapter {
         private readonly CustomFunctions _customFunctions;
 
 
-        public ExampleHostedAdapterImpl(
+        public MyAdapter(
             string id, 
-            IOptionsMonitor<ExampleHostedAdapterOptions> options,
+            IOptionsMonitor<MyAdapterOptions> options,
             IOptions<JsonOptions> jsonOptions,
             IKeyValueStore keyValueStore,
             IBackgroundTaskService taskScheduler,
-            ILogger<ExampleHostedAdapterImpl> logger
+            ILogger<MyAdapter> logger
         ) : base(id, options, taskScheduler, logger) {
             // The ConfigurationChanges class implements the IConfigurationChanges adapter feature
             // on behalf of our adapter. IConfigurationChanges allows subscribers to be notified
@@ -183,7 +183,7 @@ namespace ExampleHostedAdapter {
         // options at runtime. You can use this method to trigger any runtime changes required.
         // You can test this functionality by running the application and then changing the
         // adapter name or description in appsettings.json at runtime.
-        protected override void OnOptionsChange(ExampleHostedAdapterOptions options) {
+        protected override void OnOptionsChange(MyAdapterOptions options) {
             base.OnOptionsChange(options);
         }
 

--- a/examples/ExampleHostedAdapter/MyAdapterOptions.cs
+++ b/examples/ExampleHostedAdapter/MyAdapterOptions.cs
@@ -6,7 +6,7 @@ namespace ExampleHostedAdapter {
 
     // This class defines the runtime options used to configure your adapter.
 
-    public class ExampleHostedAdapterOptions : AdapterOptions {
+    public class MyAdapterOptions : AdapterOptions {
 
         // Add properties required to configure your adapter e.g. connection endpoints, 
         // credentials, etc. The Program.cs file is configured to bind adapter options

--- a/examples/ExampleHostedAdapter/Pages/Settings.cshtml.cs
+++ b/examples/ExampleHostedAdapter/Pages/Settings.cshtml.cs
@@ -16,11 +16,11 @@ namespace ExampleHostedAdapter.Pages {
         public IAdapter Adapter { get; }
 
         [BindProperty]
-        public ExampleHostedAdapterOptions? Options { get; set; }
+        public MyAdapterOptions? Options { get; set; }
 
-        private readonly IOptionsMonitor<ExampleHostedAdapterOptions> _optionsMonitor;
+        private readonly IOptionsMonitor<MyAdapterOptions> _optionsMonitor;
 
-        public SettingsModel(IAdapter adapter, IOptionsMonitor<ExampleHostedAdapterOptions> optionsMonitor) {
+        public SettingsModel(IAdapter adapter, IOptionsMonitor<MyAdapterOptions> optionsMonitor) {
             Adapter = adapter;
             _optionsMonitor = optionsMonitor;
         }

--- a/examples/ExampleHostedAdapter/Program.cs
+++ b/examples/ExampleHostedAdapter/Program.cs
@@ -21,8 +21,8 @@ builder.Services
 builder.Services
     .AddDataCoreAdapterAspNetCoreServices()
     .AddHostInfo(
-        name: "ExampleHostedAdapter Host",
-        description: "ASP.NET Core adapter host"
+        name: "ASP.NET Core Adapter Host",
+        description: "ASP.NET Core adapter host for My Adapter"
      )
     // Add a SQLite-based key-value store service. This can be used by our adapter to persist data
     // between restarts.
@@ -38,7 +38,7 @@ builder.Services
         return ActivatorUtilities.CreateInstance<SqliteKeyValueStore>(sp, options);
     })
     // Register the adapter options
-    .AddAdapterOptions<ExampleHostedAdapterOptions>(
+    .AddAdapterOptions<MyAdapterOptions>(
         // The adapter will look for an instance of the options with a name that matches its ID.
         Constants.AdapterId,
         // Bind the adapter options against the application configuration and ensure that they are
@@ -50,7 +50,7 @@ builder.Services
     )
     // Register the adapter. We specify the adapter ID as an additional constructor parameter
     // since this will not be supplied by the service provider.
-    .AddAdapter<ExampleHostedAdapterImpl>(Constants.AdapterId);
+    .AddAdapter<MyAdapter>(Constants.AdapterId);
 
 // Register adapter MVC controllers.
 builder.Services

--- a/examples/ExampleHostedAdapter/README_TEMPLATE.md
+++ b/examples/ExampleHostedAdapter/README_TEMPLATE.md
@@ -15,13 +15,13 @@ Client-side libraries are restored at build time via the LibMan MSBuild task. Th
 
 # Getting Started
 
-The `ExampleHostedAdapterImpl` and `ExampleHostedAdapterOptions` classes define the adapter and its runtime options respectively. You can change the names of these classes as you wish. The `ExampleHostedAdapterImpl` class is split across separate code files (`ExampleHostedAdapterImpl.cs` and `ExampleHostedAdapterImpl.ReadSnapshotTagValues.cs`). The adapter implements snapshot tag value polling directly, and indirectly implements tag search and snapshot tag value subscription features via helper classes.
+The `MyAdapter` and `MyAdapterOptions` classes define the adapter and its runtime options respectively. You can change the names of these classes as you wish. The `MyAdapter` class is split across separate code files (`MyAdapter.cs` and `MyAdapter.ReadSnapshotTagValues.cs`). The adapter implements snapshot tag value polling directly, and indirectly implements tag search and snapshot tag value subscription features via helper classes.
 
 For information about how to implement adapter features, as well as example projects, please visit the [App Store Connect adapters GitHub repository](https://github.com/intelligentplant/AppStoreConnect.Adapters).
 
-The `Program.cs` file configures the dependency injection container and application pipeline for the ASP.NET Core application using a minimal API application builder. The `appsettings.json` file provides configuration settings for the application. The `ExampleHostedAdapterOptions` that is passed to the `ExampleHostedAdapterImpl` instance at runtime is defined in the `adaptersettings.json` file. Changes to the `adaptersettings.json` file will be automatically passed to the adapter at runtime.
+The `Program.cs` file configures the dependency injection container and application pipeline for the ASP.NET Core application using a minimal API application builder. The `appsettings.json` file provides configuration settings for the application. The `MyAdapterOptions` that is passed to the `MyAdapter` instance at runtime is defined in the `adaptersettings.json` file. Changes to the `adaptersettings.json` file will be automatically passed to the adapter at runtime.
 
-The Razor Pages for the application define a basic user interface. The `Settings` page is used to configure the `ExampleHostedAdapterOptions` for the adapter at runtime. Submitting the form will overwrite the contents of the `adaptersettings.json` file. Remember to extend the form when you add new properties to the `ExampleHostedAdapterOptions` class!
+The Razor Pages for the application define a basic user interface. The `Settings` page is used to configure the `MyAdapterOptions` for the adapter at runtime. Submitting the form will overwrite the contents of the `adaptersettings.json` file. Remember to extend the form when you add new properties to the `MyAdapterOptions` class!
 
 
 # Deployment


### PR DESCRIPTION
Template adapter and options classes have been renamed to `MyAdapter` and `MyAdapterOptions` respectively.

This is to allow an out-of-the-box project to work correctly when someone specifies a project name such as `MyCompany.SomeAdapter`, as this was previously causing the adapter class to be renamed to be the same as the project name with an `Impl` suffix, which led to compilation errors when trying to run the new project.