### PR TITLE
Ensure that custom functions provider is registered

### DIFF
--- a/src/DataCore.Adapter/AdapterBaseT.cs
+++ b/src/DataCore.Adapter/AdapterBaseT.cs
@@ -554,6 +554,7 @@ namespace DataCore.Adapter {
         /// </summary>
         private void AddDefaultFeatures() {
             AddFeature<IHealthCheck>(_healthCheckManager);
+            AddFeature<ICustomFunctions>(CustomFunctions);
         }
 
 


### PR DESCRIPTION
Ensures that `AdapterBase<TOptions>` automatically registers support for the `ICustomFunctions` feature via its `CustomFunctions` property. This step previously had to be done manually but the original intention was that out-of-the-box support for custom functions was provided.